### PR TITLE
Fix whitespace in query_test assertion

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -263,7 +263,7 @@ func TestConstructMutation(t *testing.T) {
 					Content:   ReactionContentThumbsUp,
 				},
 			},
-			want: `mutation($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}`,
+			want: `mutation ($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}`,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Prior to this change: 
```
--- FAIL: TestConstructMutation (0.00s)
    query_test.go:272:
        got:  "mutation ($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}"
        want: "mutation($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}"
```