### PR TITLE
Enable custom createConn function

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -212,7 +212,7 @@ func (sc *SubscriptionClient) init() error {
 		var conn WebsocketConn
 		// allow custom websocket client
 		if sc.conn == nil {
-			conn, err = newWebsocketConn(sc)
+			conn, err = sc.createConn(sc)
 			if err == nil {
 				sc.conn = conn
 			}


### PR DESCRIPTION
Currently, I can specify a custom `createConn` function for the `SubscriptionClient` but it's never called and always falls back to the default one. This change fixes the issue.