### PR TITLE
introduce extensible query options

### DIFF
--- a/option.go
+++ b/option.go
@@ -1,0 +1,38 @@
+package graphql
+
+// OptionType represents the logic of graphql query construction
+type OptionType string
+
+const (
+	// optionTypeOperationName is private because it's option is built-in and unique
+	optionTypeOperationName      OptionType = "operation_name"
+	OptionTypeOperationDirective OptionType = "operation_directive"
+)
+
+// Option abstracts an extra render interface for the query string
+// They are optional parts. By default GraphQL queries can request data without them
+type Option interface {
+	// Type returns the supported type of the renderer
+	// available types: operation_name and operation_directive
+	Type() OptionType
+	// String returns the query component string
+	String() string
+}
+
+// operationNameOption represents the operation name render component
+type operationNameOption struct {
+	name string
+}
+
+func (ono operationNameOption) Type() OptionType {
+	return optionTypeOperationName
+}
+
+func (ono operationNameOption) String() string {
+	return ono.name
+}
+
+// OperationName creates the operation name option
+func OperationName(name string) Option {
+	return operationNameOption{name}
+}

--- a/subscription.go
+++ b/subscription.go
@@ -278,13 +278,15 @@ func (sc *SubscriptionClient) sendConnectionInit() (err error) {
 // Subscribe sends start message to server and open a channel to receive data.
 // The handler callback function will receive raw message data or error. If the call return error, onError event will be triggered
 // The function returns subscription ID and error. You can use subscription ID to unsubscribe the subscription
-func (sc *SubscriptionClient) Subscribe(v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error) (string, error) {
-	return sc.do(v, variables, handler, "")
+func (sc *SubscriptionClient) Subscribe(v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error, options ...Option) (string, error) {
+	return sc.do(v, variables, handler, options...)
 }
 
 // NamedSubscribe sends start message to server and open a channel to receive data, with operation name
-func (sc *SubscriptionClient) NamedSubscribe(name string, v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error) (string, error) {
-	return sc.do(v, variables, handler, name)
+//
+// Deprecated: this is the shortcut of Subscribe method, with NewOperationName option
+func (sc *SubscriptionClient) NamedSubscribe(name string, v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error, options ...Option) (string, error) {
+	return sc.do(v, variables, handler, append(options, OperationName(name))...)
 }
 
 // SubscribeRaw sends start message to server and open a channel to receive data, with raw query
@@ -292,8 +294,12 @@ func (sc *SubscriptionClient) SubscribeRaw(query string, variables map[string]in
 	return sc.doRaw(query, variables, handler)
 }
 
-func (sc *SubscriptionClient) do(v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error, name string) (string, error) {
-	query := constructSubscription(v, variables, name)
+func (sc *SubscriptionClient) do(v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error, options ...Option) (string, error) {
+	query, err := constructSubscription(v, variables, options...)
+	if err != nil {
+		return "", err
+	}
+
 	return sc.doRaw(query, variables, handler)
 }
 


### PR DESCRIPTION
close #16


There are extensible parts in the GraphQL query. We shouldn't required them in the method. To make it flexible, we can abstract these options as optional arguments that follow this interface.

```go
type Option interface {
	Type() OptionType
	String() string
}

client.Query(ctx context.Context, q interface{}, variables map[string]interface{}, options ...Option) error
```

Currently we support 2 option types: `operation_name` and `operation_directive`. The operation name option is built-in because it is unique. We can use the option directly with `OperationName`

```go
// query MyQuery {
//	...
// }
client.Query(ctx, &q, variables, graphql.OperationName("MyQuery"))
```

In contrast, operation directive is various and customizable on different GraphQL servers. There isn't any built-in directive in the library. You need to define yourself. For example:

```go
// define @cached directive for Hasura queries
// https://hasura.io/docs/latest/graphql/cloud/response-caching.html#enable-caching
type cachedDirective struct {
	ttl int
}

func (cd cachedDirective) Type() OptionType {
	// operation_directive
	return graphql.OptionTypeOperationDirective
}

func (cd cachedDirective) String() string {
	if cd.ttl <= 0 {
		return "@cached"
	}
	return fmt.Sprintf("@cached(ttl: %d)", cd.ttl)
}

// query MyQuery @cached {
//	...
// }
client.Query(ctx, &q, variables, graphql.OperationName("MyQuery"), cachedDirective{})
```
