### PR TITLE
Allow building queries and mutations from ordered maps ([][2]string)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,44 @@ func (c *Client) NamedQueryRaw(ctx context.Context, name string, q interface{}, 
 func (c *Client) NamedMutateRaw(ctx context.Context, name string, q interface{}, variables map[string]interface{}) (*json.RawMessage, error)
 ```
 
+### Multiple mutations with ordered map
+
+You might need to make multiple mutations in single query. It's not very convenient with structs
+so you can use ordered map `[][2]interface{}` instead.
+
+For example, to make the following GraphQL mutation:
+
+```GraphQL
+mutation($login1: String!, $login2: String!, $login3: String!) {
+	createUser(login: $login1) { login }
+	createUser(login: $login2) { login }
+	createUser(login: $login3) { login }
+}
+variables {
+	"login1": "grihabor",
+	"login2": "diman",
+	"login3": "indigo"
+}
+```
+
+You can define:
+
+```Go
+type CreateUser struct {
+	Login graphql.String
+}
+m := [][2]interface{}{
+	{"createUser(login: $login1)", &CreateUser{}},
+	{"createUser(login: $login2)", &CreateUser{}},
+	{"createUser(login: $login3)", &CreateUser{}},
+}
+variables := map[string]interface{}{
+	"login1": graphql.String("grihabor"),
+	"login2": graphql.String("diman"),
+	"login3": graphql.String("indigo"),
+}
+```
+
 Directories
 -----------
 

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -436,6 +436,9 @@ func unmarshalValue(value interface{}, v reflect.Value) error {
 	}
 	ty := v.Type()
 	if ty.Kind() == reflect.Interface {
+		if !v.Elem().IsValid() {
+			return json.Unmarshal(b, v.Addr().Interface())
+		}
 		ty = v.Elem().Type()
 	}
 	newVal := reflect.New(ty)

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -54,7 +54,13 @@ type decoder struct {
 	// The reason there's more than one stack is because we might be unmarshaling
 	// a single JSON value into multiple GraphQL fragments or embedded structs, so
 	// we keep track of them all.
-	vs [][]reflect.Value
+	vs []valueSlice
+}
+
+type valueSlice []reflect.Value
+
+func (s valueSlice) Last() reflect.Value {
+	return s[len(s)-1]
 }
 
 // Decode decodes a single JSON value from d.tokenizer into v.
@@ -63,7 +69,7 @@ func (d *decoder) Decode(v interface{}) error {
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("cannot decode into non-pointer %T", v)
 	}
-	d.vs = [][]reflect.Value{{rv.Elem()}}
+	d.vs = []valueSlice{{rv.Elem()}}
 	return d.decode()
 }
 
@@ -95,12 +101,13 @@ func (d *decoder) decode() error {
 			// If one field is raw all must be treated as raw
 			rawMessage := false
 			for i := range d.vs {
-				v := d.vs[i][len(d.vs[i])-1]
+				v := d.vs[i].Last()
 				if v.Kind() == reflect.Ptr {
 					v = v.Elem()
 				}
 				var f reflect.Value
-				if v.Kind() == reflect.Struct {
+				switch v.Kind() {
+				case reflect.Struct:
 					f = fieldByGraphQLName(v, key)
 					if f.IsValid() {
 						someFieldExist = true
@@ -109,7 +116,11 @@ func (d *decoder) decode() error {
 							rawMessage = true
 						}
 					}
-
+				case reflect.Slice:
+					f = orderedMapValueByGraphQLName(v, key)
+					if f.IsValid() {
+						someFieldExist = true
+					}
 				}
 				d.vs[i] = append(d.vs[i], f)
 			}
@@ -137,7 +148,7 @@ func (d *decoder) decode() error {
 		case d.state() == '[' && tok != json.Delim(']'):
 			someSliceExist := false
 			for i := range d.vs {
-				v := d.vs[i][len(d.vs[i])-1]
+				v := d.vs[i].Last()
 				if v.Kind() == reflect.Ptr {
 					v = v.Elem()
 				}
@@ -179,7 +190,7 @@ func (d *decoder) decode() error {
 
 				frontier := make([]reflect.Value, len(d.vs)) // Places to look for GraphQL fragments/embedded structs.
 				for i := range d.vs {
-					v := d.vs[i][len(d.vs[i])-1]
+					v := d.vs[i].Last()
 					frontier[i] = v
 					// TODO: Do this recursively or not? Add a test case if needed.
 					if v.Kind() == reflect.Ptr && v.IsNil() {
@@ -261,7 +272,7 @@ func (d *decoder) state() json.Delim {
 
 // popAllVs pops from all d.vs stacks, keeping only non-empty ones.
 func (d *decoder) popAllVs() {
-	var nonEmpty [][]reflect.Value
+	var nonEmpty []valueSlice
 	for i := range d.vs {
 		d.vs[i] = d.vs[i][:len(d.vs[i])-1]
 		if len(d.vs[i]) > 0 {
@@ -281,6 +292,18 @@ func fieldByGraphQLName(v reflect.Value, name string) reflect.Value {
 		}
 		if hasGraphQLName(v.Type().Field(i), name) {
 			return v.Field(i)
+		}
+	}
+	return reflect.Value{}
+}
+
+// orderedMapValueByGraphQLName takes [][2]string, interprets it as an ordered map
+// and returns value for corresponding key, or invalid reflect.Value if none found.
+func orderedMapValueByGraphQLName(v reflect.Value, key string) reflect.Value {
+	for i := 0; i < v.Len(); i++ {
+		pair := v.Index(i)
+		if pair.Index(0).Interface().(string) == key {
+			return pair.Index(1)
 		}
 	}
 	return reflect.Value{}

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -54,13 +54,17 @@ type decoder struct {
 	// The reason there's more than one stack is because we might be unmarshaling
 	// a single JSON value into multiple GraphQL fragments or embedded structs, so
 	// we keep track of them all.
-	vs []valueSlice
+	vs []stack
 }
 
-type valueSlice []reflect.Value
+type stack []reflect.Value
 
-func (s valueSlice) Last() reflect.Value {
+func (s stack) Top() reflect.Value {
 	return s[len(s)-1]
+}
+
+func (s stack) Pop() stack {
+	return s[:len(s)-1]
 }
 
 // Decode decodes a single JSON value from d.tokenizer into v.
@@ -69,7 +73,7 @@ func (d *decoder) Decode(v interface{}) error {
 	if rv.Kind() != reflect.Ptr {
 		return fmt.Errorf("cannot decode into non-pointer %T", v)
 	}
-	d.vs = []valueSlice{{rv.Elem()}}
+	d.vs = []stack{{rv.Elem()}}
 	return d.decode()
 }
 
@@ -101,8 +105,8 @@ func (d *decoder) decode() error {
 			// If one field is raw all must be treated as raw
 			rawMessage := false
 			for i := range d.vs {
-				v := d.vs[i].Last()
-				if v.Kind() == reflect.Ptr {
+				v := d.vs[i].Top()
+				if v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 					v = v.Elem()
 				}
 				var f reflect.Value
@@ -148,13 +152,15 @@ func (d *decoder) decode() error {
 		case d.state() == '[' && tok != json.Delim(']'):
 			someSliceExist := false
 			for i := range d.vs {
-				v := d.vs[i].Last()
+				v := d.vs[i].Top()
 				if v.Kind() == reflect.Ptr {
 					v = v.Elem()
 				}
 				var f reflect.Value
 				if v.Kind() == reflect.Slice {
-					v.Set(reflect.Append(v, reflect.Zero(v.Type().Elem()))) // v = append(v, T).
+					// we want to append the template item copy
+					// so that all the inner structure gets preserved
+					v.Set(reflect.Append(v, copyTemplate(v.Index(0)))) // v = append(v, T).
 					f = v.Index(v.Len() - 1)
 					someSliceExist = true
 				}
@@ -170,7 +176,7 @@ func (d *decoder) decode() error {
 			// Value.
 
 			for i := range d.vs {
-				v := d.vs[i][len(d.vs[i])-1]
+				v := d.vs[i].Top()
 				if !v.IsValid() {
 					continue
 				}
@@ -190,7 +196,7 @@ func (d *decoder) decode() error {
 
 				frontier := make([]reflect.Value, len(d.vs)) // Places to look for GraphQL fragments/embedded structs.
 				for i := range d.vs {
-					v := d.vs[i].Last()
+					v := d.vs[i].Top()
 					frontier[i] = v
 					// TODO: Do this recursively or not? Add a test case if needed.
 					if v.Kind() == reflect.Ptr && v.IsNil() {
@@ -205,14 +211,23 @@ func (d *decoder) decode() error {
 					if v.Kind() == reflect.Ptr {
 						v = v.Elem()
 					}
-					if v.Kind() != reflect.Struct {
-						continue
-					}
-					for i := 0; i < v.NumField(); i++ {
-						if isGraphQLFragment(v.Type().Field(i)) || v.Type().Field(i).Anonymous {
-							// Add GraphQL fragment or embedded struct.
-							d.vs = append(d.vs, []reflect.Value{v.Field(i)})
-							frontier = append(frontier, v.Field(i))
+					if v.Kind() == reflect.Struct {
+						for i := 0; i < v.NumField(); i++ {
+							if isGraphQLFragment(v.Type().Field(i)) || v.Type().Field(i).Anonymous {
+								// Add GraphQL fragment or embedded struct.
+								d.vs = append(d.vs, []reflect.Value{v.Field(i)})
+								frontier = append(frontier, v.Field(i))
+							}
+						}
+					} else if isOrderedMap(v) {
+						for i := 0; i < v.Len(); i++ {
+							pair := v.Index(i)
+							key, val := pair.Index(0), pair.Index(1)
+							if keyForGraphQLFragment(key.Interface().(string)) {
+								// Add GraphQL fragment or embedded struct.
+								d.vs = append(d.vs, []reflect.Value{val})
+								frontier = append(frontier, val)
+							}
 						}
 					}
 				}
@@ -222,7 +237,7 @@ func (d *decoder) decode() error {
 				d.pushState(tok)
 
 				for i := range d.vs {
-					v := d.vs[i][len(d.vs[i])-1]
+					v := d.vs[i].Top()
 					// TODO: Confirm this is needed, write a test case.
 					//if v.Kind() == reflect.Ptr && v.IsNil() {
 					//	v.Set(reflect.New(v.Type().Elem())) // v = new(T).
@@ -235,10 +250,28 @@ func (d *decoder) decode() error {
 					if v.Kind() != reflect.Slice {
 						continue
 					}
-					v.Set(reflect.MakeSlice(v.Type(), 0, 0)) // v = make(T, 0, 0).
+					newSlice := reflect.MakeSlice(v.Type(), 0, 0) // v = make(T, 0, 0).
+					switch v.Len() {
+					case 0:
+						// if there is no template we need to create one so that we can
+						// handle both cases (with or without a template) in the same way
+						newSlice = reflect.Append(newSlice, reflect.Zero(v.Type().Elem()))
+					case 1:
+						// if there is a template, we need to keep it at index 0
+						newSlice = reflect.Append(newSlice, v.Index(0))
+					case 2:
+						msg := fmt.Sprintf("template slice can only have 1 item")
+						panic(msg)
+					}
+					v.Set(newSlice)
 				}
-			case '}', ']':
-				// End of object or array.
+			case '}':
+				// End of object.
+				d.popAllVs()
+				d.popState()
+			case ']':
+				// End of array.
+				d.popLeftArrayTemplates()
 				d.popAllVs()
 				d.popState()
 			default:
@@ -249,6 +282,38 @@ func (d *decoder) decode() error {
 		}
 	}
 	return nil
+}
+
+func copyTemplate(template reflect.Value) reflect.Value {
+	if isOrderedMap(template) {
+		// copy slice if it's actually an ordered map
+		return copyOrderedMap(template)
+	}
+	if template.Kind() == reflect.Map {
+		msg := fmt.Sprintf("unsupported template type `%v`, use [][2]interface{} for ordered map instead", template.Type())
+		panic(msg)
+	}
+	// don't need to copy regular slice
+	return template
+}
+
+func isOrderedMap(v reflect.Value) bool {
+	if !v.IsValid() {
+		return false
+	}
+	t := v.Type()
+	return t.Kind() == reflect.Slice &&
+		t.Elem().Kind() == reflect.Array &&
+		t.Elem().Len() == 2
+}
+
+func copyOrderedMap(m reflect.Value) reflect.Value {
+	newMap := reflect.MakeSlice(m.Type(), 0, m.Len())
+	for i := 0; i < m.Len(); i++ {
+		pair := m.Index(i)
+		newMap = reflect.Append(newMap, pair)
+	}
+	return newMap
 }
 
 // pushState pushes a new parse state s onto the stack.
@@ -272,14 +337,24 @@ func (d *decoder) state() json.Delim {
 
 // popAllVs pops from all d.vs stacks, keeping only non-empty ones.
 func (d *decoder) popAllVs() {
-	var nonEmpty []valueSlice
+	var nonEmpty []stack
 	for i := range d.vs {
-		d.vs[i] = d.vs[i][:len(d.vs[i])-1]
+		d.vs[i] = d.vs[i].Pop()
 		if len(d.vs[i]) > 0 {
 			nonEmpty = append(nonEmpty, d.vs[i])
 		}
 	}
 	d.vs = nonEmpty
+}
+
+// popLeftArrayTemplates pops left from last array items of all d.vs stacks.
+func (d *decoder) popLeftArrayTemplates() {
+	for i := range d.vs {
+		v := d.vs[i].Top()
+		if v.IsValid() {
+			v.Set(v.Slice(1, v.Len()))
+		}
+	}
 }
 
 // fieldByGraphQLName returns an exported struct field of struct v
@@ -299,10 +374,11 @@ func fieldByGraphQLName(v reflect.Value, name string) reflect.Value {
 
 // orderedMapValueByGraphQLName takes [][2]string, interprets it as an ordered map
 // and returns value for corresponding key, or invalid reflect.Value if none found.
-func orderedMapValueByGraphQLName(v reflect.Value, key string) reflect.Value {
+func orderedMapValueByGraphQLName(v reflect.Value, name string) reflect.Value {
 	for i := 0; i < v.Len(); i++ {
 		pair := v.Index(i)
-		if pair.Index(0).Interface().(string) == key {
+		key := pair.Index(0).Interface().(string)
+		if keyHasGraphQLName(key, name) {
 			return pair.Index(1)
 		}
 	}
@@ -317,6 +393,10 @@ func hasGraphQLName(f reflect.StructField, name string) bool {
 		//return caseconv.MixedCapsToLowerCamelCase(f.Name) == name
 		return strings.EqualFold(f.Name, name)
 	}
+	return keyHasGraphQLName(value, name)
+}
+
+func keyHasGraphQLName(value, name string) bool {
 	value = strings.TrimSpace(value) // TODO: Parse better.
 	if strings.HasPrefix(value, "...") {
 		// GraphQL fragment. It doesn't have a name.
@@ -337,6 +417,11 @@ func isGraphQLFragment(f reflect.StructField) bool {
 	if !ok {
 		return false
 	}
+	return keyForGraphQLFragment(value)
+}
+
+// isGraphQLFragment reports whether ordered map kv pair f is a GraphQL fragment.
+func keyForGraphQLFragment(value string) bool {
 	value = strings.TrimSpace(value) // TODO: Parse better.
 	return strings.HasPrefix(value, "...")
 }
@@ -349,5 +434,15 @@ func unmarshalValue(value interface{}, v reflect.Value) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(b, v.Addr().Interface())
+	ty := v.Type()
+	if ty.Kind() == reflect.Interface {
+		ty = v.Elem().Type()
+	}
+	newVal := reflect.New(ty)
+	err = json.Unmarshal(b, newVal.Interface())
+	if err != nil {
+		return err
+	}
+	v.Set(newVal.Elem())
+	return nil
 }

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -119,7 +119,7 @@ func TestUnmarshalGraphQL_orderedMap(t *testing.T) {
 		{"foo", graphql.String("bar")},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Error("not equal")
+		t.Errorf("not equal: %v != %v", got, want)
 	}
 }
 
@@ -147,36 +147,7 @@ func TestUnmarshalGraphQL_array(t *testing.T) {
 		Baz: []graphql.String(nil),
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Error("not equal")
-	}
-}
-
-func TestUnmarshalGraphQL_orderedMapInArray(t *testing.T) {
-	type query struct {
-		Foo [][][2]interface{}
-	}
-	got := query{
-		Foo: [][][2]interface{}{{
-			{"x", graphql.String("")},
-		}},
-	}
-	err := jsonutil.UnmarshalGraphQL([]byte(`{
-		"foo": [
-			{"x": "bar"}
-			{"x": "baz"}
-		],
-	}`), &got)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := query{
-		Foo: [][][2]interface{}{{
-			{"x", "bar"},
-			{"x", "baz"},
-		}},
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Error("not equal")
+		t.Errorf("not equal: %v != %v", got, want)
 	}
 }
 
@@ -214,6 +185,35 @@ func TestUnmarshalGraphQL_objectArray(t *testing.T) {
 		Foo: []struct{ Name graphql.String }{
 			{"bar"},
 			{"baz"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Error("not equal")
+	}
+}
+
+func TestUnmarshalGraphQL_orderedMapArray(t *testing.T) {
+	type query struct {
+		Foo [][][2]interface{}
+	}
+	got := query{
+		Foo: [][][2]interface{}{
+			{{"name", graphql.String("")}},
+		},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"foo": [
+			{"name": "bar"},
+			{"name": "baz"}
+		]
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		Foo: [][][2]interface{}{
+			{{"name", graphql.String("bar")}},
+			{{"name", graphql.String("baz")}},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -266,6 +266,37 @@ func TestUnmarshalGraphQL_objectPointerArray(t *testing.T) {
 			{"bar"},
 			nil,
 			{"baz"},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Error("not equal")
+	}
+}
+
+func TestUnmarshalGraphQL_orderedMapNullInArray(t *testing.T) {
+	type query struct {
+		Foo [][][2]interface{}
+	}
+	got := query{
+		Foo: [][][2]interface{}{
+			{{"name", ""}},
+		},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"foo": [
+			{"name": "bar"},
+			null,
+			{"name": "baz"}
+		]
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		Foo: [][][2]interface{}{
+			{{"name", "bar"}},
+			nil,
+			{{"name", "baz"}},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -339,6 +370,18 @@ func TestUnmarshalGraphQL_multipleValues(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_multipleValuesInOrderedMap(t *testing.T) {
+	type query [][2]interface{}
+	q := query{{"foo", ""}}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{"foo": "bar"}{"foo": "baz"}`), &q)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if got, want := err.Error(), "invalid token '{' after top-level value"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+}
+
 func TestUnmarshalGraphQL_union(t *testing.T) {
 	/*
 		{
@@ -395,6 +438,56 @@ func TestUnmarshalGraphQL_union(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Error("not equal")
+	}
+}
+
+func TestUnmarshalGraphQL_orderedMapUnion(t *testing.T) {
+	/*
+		{
+			__typename
+			... on ClosedEvent {
+				createdAt
+				actor {login}
+			}
+			... on ReopenedEvent {
+				createdAt
+				actor {login}
+			}
+		}
+	*/
+	actor := [][2]interface{}{{"login", ""}}
+	closedEvent := [][2]interface{}{{"actor", actor}, {"createdAt", time.Time{}}}
+	reopenedEvent := [][2]interface{}{{"actor", actor}, {"createdAt", time.Time{}}}
+	got := [][2]interface{}{
+		{"__typename", ""},
+		{"... on ClosedEvent", closedEvent},
+		{"... on ReopenedEvent", reopenedEvent},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"__typename": "ClosedEvent",
+		"createdAt": "2017-06-29T04:12:01Z",
+		"actor": {
+			"login": "shurcooL-test"
+		}
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := [][2]interface{}{
+		{"__typename", "ClosedEvent"},
+		{"... on ClosedEvent", [][2]interface{}{
+			{"actor", [][2]interface{}{{"login", "shurcooL-test"}}},
+			{"createdAt", time.Unix(1498709521, 0).UTC()},
+		}},
+		{"... on ReopenedEvent", [][2]interface{}{
+			{"actor", [][2]interface{}{{"login", "shurcooL-test"}}},
+			{"createdAt", time.Unix(1498709521, 0).UTC()},
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("not equal:\ngot: %v\nwant: %v", got, want)
+		createdAt := got[1][1].([][2]interface{})[1]
+		t.Logf("key: %s, type: %v", createdAt[0], reflect.TypeOf(createdAt[1]))
 	}
 }
 

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -104,6 +104,25 @@ func TestUnmarshalGraphQL_jsonRawTag(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_orderedMap(t *testing.T) {
+	type query [][2]interface{}
+	got := query{
+		{"foo", graphql.String("")},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"foo": "bar"
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		{"foo", graphql.String("bar")},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Error("not equal")
+	}
+}
+
 func TestUnmarshalGraphQL_array(t *testing.T) {
 	type query struct {
 		Foo []graphql.String
@@ -126,6 +145,35 @@ func TestUnmarshalGraphQL_array(t *testing.T) {
 		Foo: []graphql.String{"bar", "baz"},
 		Bar: []graphql.String{},
 		Baz: []graphql.String(nil),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Error("not equal")
+	}
+}
+
+func TestUnmarshalGraphQL_orderedMapInArray(t *testing.T) {
+	type query struct {
+		Foo [][][2]interface{}
+	}
+	got := query{
+		Foo: [][][2]interface{}{{
+			{"x", graphql.String("")},
+		}},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+		"foo": [
+			{"x": "bar"}
+			{"x": "baz"}
+		],
+	}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := query{
+		Foo: [][][2]interface{}{{
+			{"x", "bar"},
+			{"x", "baz"},
+		}},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Error("not equal")

--- a/query.go
+++ b/query.go
@@ -155,16 +155,18 @@ func writeArgumentType(w io.Writer, t reflect.Type, value bool) {
 // E.g., struct{Foo Int, BarBaz *Boolean} -> "{foo,barBaz}".
 func query(v interface{}) string {
 	var buf bytes.Buffer
-	writeQuery(&buf, reflect.TypeOf(v), false)
+	writeQuery(&buf, reflect.TypeOf(v), reflect.ValueOf(v), false)
 	return buf.String()
 }
 
 // writeQuery writes a minified query for t to w.
 // If inline is true, the struct fields of t are inlined into parent struct.
-func writeQuery(w io.Writer, t reflect.Type, inline bool) {
+func writeQuery(w io.Writer, t reflect.Type, v reflect.Value, inline bool) {
 	switch t.Kind() {
-	case reflect.Ptr, reflect.Slice:
-		writeQuery(w, t.Elem(), false)
+	case reflect.Ptr:
+		writeQuery(w, t.Elem(), ElemSafe(v), false)
+	case reflect.Slice:
+		writeQuery(w, t.Elem(), IndexSafe(v, 0), false)
 	case reflect.Struct:
 		// If the type implements json.Unmarshaler, it's a scalar. Don't expand it.
 		if reflect.PtrTo(t).Implements(jsonUnmarshaler) {
@@ -187,12 +189,51 @@ func writeQuery(w io.Writer, t reflect.Type, inline bool) {
 					io.WriteString(w, ident.ParseMixedCaps(f.Name).ToLowerCamelCase())
 				}
 			}
-			writeQuery(w, f.Type, inlineField)
+			writeQuery(w, f.Type, FieldSafe(v, i), inlineField)
 		}
 		if !inline {
 			io.WriteString(w, "}")
 		}
+	case reflect.Map: // handle map[string]interface{}
+		it := v.MapRange()
+		_, _ = io.WriteString(w, "{")
+		for it.Next() {
+			// it.Value() returns interface{}, so we need to use reflect.ValueOf
+			// to cast it away
+			key, val := it.Key(), reflect.ValueOf(it.Value().Interface())
+			_, _ = io.WriteString(w, key.String())
+			writeQuery(w, val.Type(), val, false)
+		}
+		_, _ = io.WriteString(w, "}")
 	}
+}
+
+func IndexSafe(v reflect.Value, i int) reflect.Value {
+	if v.IsValid() && i < v.Len() {
+		return v.Index(i)
+	}
+	return reflect.ValueOf(nil)
+}
+
+func TypeSafe(v reflect.Value) reflect.Type {
+	if v.IsValid() {
+		return v.Type()
+	}
+	return reflect.TypeOf((interface{})(nil))
+}
+
+func ElemSafe(v reflect.Value) reflect.Value {
+	if v.IsValid() {
+		return v.Elem()
+	}
+	return reflect.ValueOf(nil)
+}
+
+func FieldSafe(valStruct reflect.Value, i int) reflect.Value {
+	if valStruct.IsValid() {
+		return valStruct.Field(i)
+	}
+	return reflect.ValueOf(nil)
 }
 
 var jsonUnmarshaler = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()

--- a/query.go
+++ b/query.go
@@ -226,13 +226,6 @@ func IndexSafe(v reflect.Value, i int) reflect.Value {
 	return reflect.ValueOf(nil)
 }
 
-func TypeSafe(v reflect.Value) reflect.Type {
-	if v.IsValid() {
-		return v.Type()
-	}
-	return reflect.TypeOf((interface{})(nil))
-}
-
 func ElemSafe(v reflect.Value) reflect.Value {
 	if v.IsValid() {
 		return v.Elem()

--- a/query.go
+++ b/query.go
@@ -165,8 +165,6 @@ func writeQuery(w io.Writer, t reflect.Type, v reflect.Value, inline bool) {
 	switch t.Kind() {
 	case reflect.Ptr:
 		writeQuery(w, t.Elem(), ElemSafe(v), false)
-	case reflect.Slice:
-		writeQuery(w, t.Elem(), IndexSafe(v, 0), false)
 	case reflect.Struct:
 		// If the type implements json.Unmarshaler, it's a scalar. Don't expand it.
 		if reflect.PtrTo(t).Implements(jsonUnmarshaler) {
@@ -194,17 +192,30 @@ func writeQuery(w io.Writer, t reflect.Type, v reflect.Value, inline bool) {
 		if !inline {
 			io.WriteString(w, "}")
 		}
-	case reflect.Map: // handle map[string]interface{}
-		it := v.MapRange()
+	case reflect.Slice:
+		if t.Elem().Kind() != reflect.Array {
+			writeQuery(w, t.Elem(), IndexSafe(v, 0), false)
+			return
+		}
+		// handle [][2]interface{} like an ordered map
+		if t.Elem().Len() != 2 {
+			err := fmt.Errorf("only arrays of len 2 are supported, got %v", t.Elem())
+			panic(err.Error())
+		}
+		sliceOfPairs := v
 		_, _ = io.WriteString(w, "{")
-		for it.Next() {
+		for i := 0; i < sliceOfPairs.Len(); i++ {
+			pair := sliceOfPairs.Index(i)
 			// it.Value() returns interface{}, so we need to use reflect.ValueOf
 			// to cast it away
-			key, val := it.Key(), reflect.ValueOf(it.Value().Interface())
-			_, _ = io.WriteString(w, key.String())
+			key, val := pair.Index(0), reflect.ValueOf(pair.Index(1).Interface())
+			_, _ = io.WriteString(w, key.Interface().(string))
 			writeQuery(w, val.Type(), val, false)
 		}
 		_, _ = io.WriteString(w, "}")
+	case reflect.Map:
+		err := fmt.Errorf("type %v is not supported, use [][2]interface{} instead", t)
+		panic(err.Error())
 	}
 }
 

--- a/query_test.go
+++ b/query_test.go
@@ -231,7 +231,7 @@ func TestConstructQuery(t *testing.T) {
 				"repositoryName":  String("test-repo"),
 				"issueNumber":     Int(1),
 			},
-			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
+			want: `query ($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
 		},
 		// check inner maps work inside slices
 		{
@@ -264,7 +264,7 @@ func TestConstructQuery(t *testing.T) {
 				"repositoryName":  String("test-repo"),
 				"issueNumber":     Int(1),
 			},
-			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
+			want: `query ($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
 		},
 		// Embedded structs without graphql tag should be inlined in query.
 		{
@@ -359,7 +359,7 @@ func TestConstructMutation(t *testing.T) {
 				"login1": String("grihabor"),
 				"login2": String("diman"),
 			},
-			want: "mutation($login1:String!$login2:String!){createUser(login:$login1){login}deleteUser(login:$login2){login}}",
+			want: "mutation ($login1:String!$login2:String!){createUser(login:$login1){login}deleteUser(login:$login2){login}}",
 		},
 	}
 	for _, tc := range tests {

--- a/query_test.go
+++ b/query_test.go
@@ -211,7 +211,7 @@ func TestConstructQuery(t *testing.T) {
 		{
 			inV: func() interface{} {
 				type query struct {
-					Repository map[string]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+					Repository [][2]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 				}
 				type issue struct {
 					ReactionGroups []struct {
@@ -222,8 +222,8 @@ func TestConstructQuery(t *testing.T) {
 						} `graphql:"users(first:10)"`
 					}
 				}
-				return query{Repository: map[string]interface{}{
-					"issue(number: $issueNumber)": issue{},
+				return query{Repository: [][2]interface{}{
+					{"issue(number: $issueNumber)", issue{}},
 				}}
 			}(),
 			inVariables: map[string]interface{}{
@@ -237,26 +237,26 @@ func TestConstructQuery(t *testing.T) {
 		{
 			inV: func() interface{} {
 				type query struct {
-					Repository map[string]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+					Repository [][2]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
 				}
 				type issue struct {
 					ReactionGroups []struct {
-						Users map[string]interface{} `graphql:"users(first:10)"`
+						Users [][2]interface{} `graphql:"users(first:10)"`
 					}
 				}
 				type nodes []struct {
 					Login String
 				}
-				return query{Repository: map[string]interface{}{
-					"issue(number: $issueNumber)": issue{
+				return query{Repository: [][2]interface{}{
+					{"issue(number: $issueNumber)", issue{
 						ReactionGroups: []struct {
-							Users map[string]interface{} `graphql:"users(first:10)"`
+							Users [][2]interface{} `graphql:"users(first:10)"`
 						}{
-							{Users: map[string]interface{}{
-								"nodes": nodes{},
+							{Users: [][2]interface{}{
+								{"nodes", nodes{}},
 							}},
 						},
-					},
+					}},
 				}}
 			}(),
 			inVariables: map[string]interface{}{
@@ -351,9 +351,9 @@ func TestConstructMutation(t *testing.T) {
 			want: `mutation ($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}`,
 		},
 		{
-			inV: map[string]interface{}{
-				"createUser(login:$login1)": &CreateUser{},
-				"deleteUser(login:$login2)": &DeleteUser{},
+			inV: [][2]interface{}{
+				{"createUser(login:$login1)", &CreateUser{}},
+				{"deleteUser(login:$login2)", &DeleteUser{}},
 			},
 			inVariables: map[string]interface{}{
 				"login1": String("grihabor"),

--- a/query_test.go
+++ b/query_test.go
@@ -207,6 +207,65 @@ func TestConstructQuery(t *testing.T) {
 			},
 			want: `query SearchRepository($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!) @cached(ttl: 100) {repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
 		},
+		// check test above works with repository inner map
+		{
+			inV: func() interface{} {
+				type query struct {
+					Repository map[string]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+				}
+				type issue struct {
+					ReactionGroups []struct {
+						Users struct {
+							Nodes []struct {
+								Login String
+							}
+						} `graphql:"users(first:10)"`
+					}
+				}
+				return query{Repository: map[string]interface{}{
+					"issue(number: $issueNumber)": issue{},
+				}}
+			}(),
+			inVariables: map[string]interface{}{
+				"repositoryOwner": String("shurcooL-test"),
+				"repositoryName":  String("test-repo"),
+				"issueNumber":     Int(1),
+			},
+			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
+		},
+		// check inner maps work inside slices
+		{
+			inV: func() interface{} {
+				type query struct {
+					Repository map[string]interface{} `graphql:"repository(owner: $repositoryOwner, name: $repositoryName)"`
+				}
+				type issue struct {
+					ReactionGroups []struct {
+						Users map[string]interface{} `graphql:"users(first:10)"`
+					}
+				}
+				type nodes []struct {
+					Login String
+				}
+				return query{Repository: map[string]interface{}{
+					"issue(number: $issueNumber)": issue{
+						ReactionGroups: []struct {
+							Users map[string]interface{} `graphql:"users(first:10)"`
+						}{
+							{Users: map[string]interface{}{
+								"nodes": nodes{},
+							}},
+						},
+					},
+				}}
+			}(),
+			inVariables: map[string]interface{}{
+				"repositoryOwner": String("shurcooL-test"),
+				"repositoryName":  String("test-repo"),
+				"issueNumber":     Int(1),
+			},
+			want: `query($issueNumber:Int!$repositoryName:String!$repositoryOwner:String!){repository(owner: $repositoryOwner, name: $repositoryName){issue(number: $issueNumber){reactionGroups{users(first:10){nodes{login}}}}}}`,
+		},
 		// Embedded structs without graphql tag should be inlined in query.
 		{
 			inV: func() interface{} {
@@ -257,6 +316,14 @@ func TestConstructQuery(t *testing.T) {
 	}
 }
 
+type CreateUser struct {
+	Login string
+}
+
+type DeleteUser struct {
+	Login string
+}
+
 func TestConstructMutation(t *testing.T) {
 	tests := []struct {
 		inV         interface{}
@@ -282,6 +349,17 @@ func TestConstructMutation(t *testing.T) {
 				},
 			},
 			want: `mutation ($input:AddReactionInput!){addReaction(input:$input){subject{reactionGroups{users{totalCount}}}}}`,
+		},
+		{
+			inV: map[string]interface{}{
+				"createUser(login:$login1)": &CreateUser{},
+				"deleteUser(login:$login2)": &DeleteUser{},
+			},
+			inVariables: map[string]interface{}{
+				"login1": String("grihabor"),
+				"login2": String("diman"),
+			},
+			want: "mutation($login1:String!$login2:String!){createUser(login:$login1){login}deleteUser(login:$login2){login}}",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Suppose I can create user like this
```GraphQL
mutation($login: String!) {
	createUser(login: $login) { login }
}
variables {
	"login": "grihabor"
}
```
Now I'd like to create multiple users in single request
```GraphQL
mutation($login1: String!, $login2: String!, $login3: String!) {
	createUser(login: $login1) { login }
	createUser(login: $login2) { login }
	createUser(login: $login3) { login }
}
variables {
	"login1": "grihabor",
        "login2": "diman",
        "login3": "indigo",
}
```
It would be convenient to implement it in code with ordered map
```Go
type CreateUser struct {
	Login graphql.String
}
m := [][2]interface{}{
	{"createUser(login: $login1)", &CreateUser{}},
	{"createUser(login: $login2)", &CreateUser{}},
	{"createUser(login: $login3)", &CreateUser{}},
}
variables := map[string]interface{}{
	"login1": "grihabor",
	"login2": "diman",
	"login3": "indigo",
}
_ = client.Mutate(context.Background(), &m, variables)
```
Implementation is in the pr