### PR TITLE
Call v.Elem() to cast interface{} away (followup for #20)

### DIFF
--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -106,7 +106,7 @@ func (d *decoder) decode() error {
 			rawMessage := false
 			for i := range d.vs {
 				v := d.vs[i].Top()
-				if v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+				for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 					v = v.Elem()
 				}
 				var f reflect.Value
@@ -153,7 +153,7 @@ func (d *decoder) decode() error {
 			someSliceExist := false
 			for i := range d.vs {
 				v := d.vs[i].Top()
-				if v.Kind() == reflect.Ptr {
+				for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 					v = v.Elem()
 				}
 				var f reflect.Value
@@ -212,7 +212,7 @@ func (d *decoder) decode() error {
 				for len(frontier) > 0 {
 					v := frontier[0]
 					frontier = frontier[1:]
-					if v.Kind() == reflect.Ptr {
+					for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 						v = v.Elem()
 					}
 					if v.Kind() == reflect.Struct {
@@ -248,7 +248,7 @@ func (d *decoder) decode() error {
 					//}
 
 					// Reset slice to empty (in case it had non-zero initial value).
-					if v.Kind() == reflect.Ptr {
+					for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
 						v = v.Elem()
 					}
 					if v.Kind() != reflect.Slice {

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -133,10 +133,10 @@ func TestUnmarshalGraphQL_orderedMapAlias(t *testing.T) {
 	}
 	err := jsonutil.UnmarshalGraphQL([]byte(`{
       "update0": {
-        "name": "grihabor",
+        "name": "grihabor"
       },
       "update1": {
-        "name": "diman",
+        "name": "diman"
       }
 }`), &got)
 	if err != nil {

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -123,6 +123,34 @@ func TestUnmarshalGraphQL_orderedMap(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_orderedMapAlias(t *testing.T) {
+	type Update struct {
+		Name graphql.String `graphql:"name"`
+	}
+	got := [][2]interface{}{
+		{"update0:update(name:$name0)", &Update{}},
+		{"update1:update(name:$name1)", &Update{}},
+	}
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+      "update0": {
+        "name": "grihabor",
+      },
+      "update1": {
+        "name": "diman",
+      }
+}`), &got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := [][2]interface{}{
+		{"update0:update(name:$name0)", &Update{Name: "grihabor"}},
+		{"update1:update(name:$name1)", &Update{Name: "diman"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("not equal: %v != %v", got, want)
+	}
+}
+
 func TestUnmarshalGraphQL_array(t *testing.T) {
 	type query struct {
 		Foo []graphql.String


### PR DESCRIPTION
It's a followup for #20, which introduced `[][2]interface{}` to allow building arbitrary queries at runtime. But when we access `interface{}` in reflect we need to call `v.Elem()` to get the actual object inside. This is properly done in the pr