### PR TITLE
export Errors and add extensions to allow clients parse the error

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -126,8 +126,7 @@ func (c *Client) doRaw(ctx context.Context, op operationType, v interface{}, var
 	}
 	var out struct {
 		Data   *json.RawMessage
-		Errors errors
-		//Extensions interface{} // Unused.
+		Errors Errors
 	}
 	err = json.NewDecoder(resp.Body).Decode(&out)
 	if err != nil {
@@ -181,8 +180,7 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	}
 	var out struct {
 		Data   *json.RawMessage
-		Errors errors
-		//Extensions interface{} // Unused.
+		Errors Errors
 	}
 	err = json.NewDecoder(resp.Body).Decode(&out)
 	if err != nil {
@@ -206,16 +204,17 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 // If returned via error interface, the slice is expected to contain at least 1 element.
 //
 // Specification: https://facebook.github.io/graphql/#sec-Errors.
-type errors []struct {
-	Message   string
-	Locations []struct {
+type Errors []struct {
+	Message    string
+	Extensions map[string]interface{}
+	Locations  []struct {
 		Line   int
 		Column int
 	}
 }
 
 // Error implements error interface.
-func (e errors) Error() string {
+func (e Errors) Error() string {
 	b := strings.Builder{}
 	for _, err := range e {
 		b.WriteString(fmt.Sprintf("Message: %s, Locations: %+v", err.Message, err.Locations))

--- a/subscription.go
+++ b/subscription.go
@@ -443,8 +443,7 @@ func (sc *SubscriptionClient) Run() error {
 				}
 				var out struct {
 					Data   *json.RawMessage
-					Errors errors
-					//Extensions interface{} // Unused.
+					Errors Errors
 				}
 
 				err = json.Unmarshal(message.Payload, &out)


### PR DESCRIPTION
Right now dealing with errors is not very graceful as you need to rely on parsing `err.Error()`. Exporting the error and adding `extensions` isn't ideal either but at least it let's you try to treat hasura errors a bit more gracefully and do things like:

```
func parseGraphqlError(err error) error {
	var ghErr graphql.Errors
	if errors.As(err, &ghErr) {
		code, ok := ghErr[0].Extensions["code"]
		if !ok {
			return err
		}
		switch code {
		case "access-denied":
			...
		default:
			return err
		}
	}

	return err
}
```

allowing you to treat errors you may be interested in.