### PR TITLE
Allow tagging of the field as having a scalar GraphQL type

### DIFF
--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -104,6 +105,7 @@ func (d *decoder) decode() error {
 			someFieldExist := false
 			// If one field is raw all must be treated as raw
 			rawMessage := false
+			isScalar := false
 			for i := range d.vs {
 				v := d.vs[i].Top()
 				for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
@@ -112,7 +114,7 @@ func (d *decoder) decode() error {
 				var f reflect.Value
 				switch v.Kind() {
 				case reflect.Struct:
-					f = fieldByGraphQLName(v, key)
+					f, isScalar = fieldByGraphQLName(v, key)
 					if f.IsValid() {
 						someFieldExist = true
 						// Check for special embedded json
@@ -132,10 +134,10 @@ func (d *decoder) decode() error {
 				return fmt.Errorf("struct field for %q doesn't exist in any of %v places to unmarshal", key, len(d.vs))
 			}
 
-			if rawMessage {
+			if rawMessage || isScalar {
 				// Read the next complete object from the json stream
 				var data json.RawMessage
-				d.tokenizer.Decode(&data)
+				_ = d.tokenizer.Decode(&data)
 				tok = data
 			} else {
 				// We've just consumed the current token, which was the key.
@@ -361,17 +363,17 @@ func (d *decoder) popLeftArrayTemplates() {
 
 // fieldByGraphQLName returns an exported struct field of struct v
 // that matches GraphQL name, or invalid reflect.Value if none found.
-func fieldByGraphQLName(v reflect.Value, name string) reflect.Value {
+func fieldByGraphQLName(v reflect.Value, name string) (val reflect.Value, taggedAsScalar bool) {
 	for i := 0; i < v.NumField(); i++ {
 		if v.Type().Field(i).PkgPath != "" {
 			// Skip unexported field.
 			continue
 		}
 		if hasGraphQLName(v.Type().Field(i), name) {
-			return v.Field(i)
+			return v.Field(i), hasScalarTag(v.Type().Field(i))
 		}
 	}
-	return reflect.Value{}
+	return reflect.Value{}, false
 }
 
 // orderedMapValueByGraphQLName takes [][2]string, interprets it as an ordered map
@@ -385,6 +387,15 @@ func orderedMapValueByGraphQLName(v reflect.Value, name string) reflect.Value {
 		}
 	}
 	return reflect.Value{}
+}
+
+func hasScalarTag(f reflect.StructField) bool {
+	return isTrue(f.Tag.Get("scalar"))
+}
+
+func isTrue(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
 }
 
 // hasGraphQLName reports whether struct field f has GraphQL name.

--- a/internal/jsonutil/graphql.go
+++ b/internal/jsonutil/graphql.go
@@ -137,7 +137,10 @@ func (d *decoder) decode() error {
 			if rawMessage || isScalar {
 				// Read the next complete object from the json stream
 				var data json.RawMessage
-				_ = d.tokenizer.Decode(&data)
+				err = d.tokenizer.Decode(&data)
+				if err != nil {
+					return err
+				}
 				tok = data
 			} else {
 				// We've just consumed the current token, which was the key.

--- a/internal/jsonutil/graphql_test.go
+++ b/internal/jsonutil/graphql_test.go
@@ -104,6 +104,42 @@ func TestUnmarshalGraphQL_jsonRawTag(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGraphQL_fieldAsScalar(t *testing.T) {
+	type query struct {
+		Data    json.RawMessage  `scalar:"true"`
+		DataPtr *json.RawMessage `scalar:"true"`
+		Another string
+		Tags    map[string]int `scalar:"true"`
+	}
+	var got query
+	err := jsonutil.UnmarshalGraphQL([]byte(`{
+                "Data" : {"ValA":1,"ValB":"foo"},
+                "DataPtr" : {"ValC":3,"ValD":false},
+		"Another" : "stuff",
+                "Tags": {
+                    "keyA": 2,
+                    "keyB": 3
+                }
+        }`), &got)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataPtr := json.RawMessage(`{"ValC":3,"ValD":false}`)
+	want := query{
+		Data:    json.RawMessage(`{"ValA":1,"ValB":"foo"}`),
+		DataPtr: &dataPtr,
+		Another: "stuff",
+		Tags: map[string]int{
+			"keyA": 2,
+			"keyB": 3,
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("not equal: %v %v", want, got)
+	}
+}
+
 func TestUnmarshalGraphQL_orderedMap(t *testing.T) {
 	type query [][2]interface{}
 	got := query{

--- a/query.go
+++ b/query.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/hasura/go-graphql-client/ident"
@@ -187,6 +188,10 @@ func writeQuery(w io.Writer, t reflect.Type, v reflect.Value, inline bool) {
 					io.WriteString(w, ident.ParseMixedCaps(f.Name).ToLowerCamelCase())
 				}
 			}
+			// Skip writeQuery if the GraphQL type associated with the filed is scalar
+			if isTrue(f.Tag.Get("scalar")) {
+				continue
+			}
 			writeQuery(w, f.Type, FieldSafe(v, i), inlineField)
 		}
 		if !inline {
@@ -241,3 +246,8 @@ func FieldSafe(valStruct reflect.Value, i int) reflect.Value {
 }
 
 var jsonUnmarshaler = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
+
+func isTrue(s string) bool {
+	b, _ := strconv.ParseBool(s)
+	return b
+}

--- a/query_test.go
+++ b/query_test.go
@@ -305,6 +305,29 @@ func TestConstructQuery(t *testing.T) {
 			}{},
 			want: `{viewer{login,createdAt,id,databaseId}}`,
 		},
+		{
+			inV: struct {
+				Viewer struct {
+					ID         interface{}
+					Login      string
+					CreatedAt  time.Time
+					DatabaseID int
+				}
+				Tags map[string]interface{} `scalar:"true"`
+			}{},
+			want: `{viewer{id,login,createdAt,databaseId},tags}`,
+		},
+		{
+			inV: struct {
+				Viewer struct {
+					ID         interface{}
+					Login      string
+					CreatedAt  time.Time
+					DatabaseID int
+				} `scalar:"true"`
+			}{},
+			want: `{viewer}`,
+		},
 	}
 	for _, tc := range tests {
 		got, err := constructQuery(tc.inV, tc.inVariables, tc.options...)


### PR DESCRIPTION
This change allows us to specify that a field in a struct has a
scalar GraphQL type associated with it. This is done by adding
the tag `scalar:"true"` to the field. This would allow us to
- Avoid expansion of the field during request query generation,
  even when the golang type of the field is a struct
- When the response is decoded, the value is simply JSON decoded,
  instead of the much stricter GraphQL decode.
- Types like map[string]interface{}, json.RawMessage, etc should
  work as far as the corresponding fields are marked as scalar