### PR TITLE
add debug modes and expose GraphQL builder functions for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,10 @@ func ConstructMutation(v interface{}, variables map[string]interface{}, options 
 
 // ConstructSubscription build GraphQL subscription string from struct and variables
 func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) 
+
+// UnmarshalGraphQL parses the JSON-encoded GraphQL response data and stores
+// the result in the GraphQL query data structure pointed to by v.
+func UnmarshalGraphQL(data []byte, v interface{}) error 
 ```
 
 Directories

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
 			- [Authentication](#authentication-1)
 			- [Options](#options)
 			- [Events](#events)
+			- [Custom HTTP Client](#custom-http-client)
 			- [Custom WebSocket client](#custom-websocket-client)
 		- [Options](#options-1)
 		- [With operation name (deprecated)](#with-operation-name-deprecated)
@@ -499,6 +500,19 @@ client.OnDisconnected(fn func())
 // If this function is empty, or returns nil, the error is ignored
 // If returns error, the websocket connection will be terminated
 client.OnError(onError func(sc *SubscriptionClient, err error) error)
+```
+
+#### Custom HTTP Client
+
+Use `WithWebSocketOptions` to customize the HTTP client which is used by the subscription client.
+
+```go
+client.WithWebSocketOptions(WebsocketOptions{
+	HTTPClient: &http.Client{
+		Transport: http.DefaultTransport,
+		Timeout: time.Minute,
+	}
+})
 ```
 
 #### Custom WebSocket client

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
 		- [With operation name (deprecated)](#with-operation-name-deprecated)
 		- [Raw bytes response](#raw-bytes-response)
 		- [Multiple mutations with ordered map](#multiple-mutations-with-ordered-map)
+		- [Debugging and Unit test](#debugging-and-unit-test)
 	- [Directories](#directories)
 	- [References](#references)
 	- [License](#license)
@@ -663,6 +664,55 @@ variables := map[string]interface{}{
 	"login2": graphql.String("diman"),
 	"login3": graphql.String("indigo"),
 }
+```
+
+### Debugging and Unit test
+
+Enable debug mode with the `WithDebug` function. If the request is failed, the request and response information will be included in `extensions[].internal` property.
+
+```json
+{
+	"errors": [
+		{
+			"message":"Field 'user' is missing required arguments: login",
+			"extensions": {
+				"internal": {
+					"request": {
+						"body":"{\"query\":\"{user{name}}\"}",
+						"headers": {
+							"Content-Type": ["application/json"]
+						}
+					},
+					"response": {
+						"body":"{\"errors\": [{\"message\": \"Field 'user' is missing required arguments: login\",\"locations\": [{\"line\": 7,\"column\": 3}]}]}",
+						"headers": {
+							"Content-Type": ["application/json"]
+						}
+					}
+				}
+			},
+			"locations": [
+				{
+					"line":7,
+					"column":3
+				}
+			]
+		}
+	]
+}
+```
+
+Because the GraphQL query string is generated in runtime using reflection, it isn't really safe. To assure the GraphQL query is expected, it's necessary to write some unit test for query construction.
+
+```go
+// ConstructQuery build GraphQL query string from struct and variables
+func ConstructQuery(v interface{}, variables map[string]interface{}, options ...Option) (string, error)
+
+// ConstructQuery build GraphQL mutation string from struct and variables
+func ConstructMutation(v interface{}, variables map[string]interface{}, options ...Option) (string, error)
+
+// ConstructSubscription build GraphQL subscription string from struct and variables
+func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) 
 ```
 
 Directories

--- a/graphql.go
+++ b/graphql.go
@@ -356,6 +356,16 @@ func (e Error) withResponse(res *http.Response, bodyReader io.Reader) Error {
 	return e
 }
 
+// UnmarshalGraphQL parses the JSON-encoded GraphQL response data and stores
+// the result in the GraphQL query data structure pointed to by v.
+//
+// The implementation is created on top of the JSON tokenizer available
+// in "encoding/json".Decoder.
+// This function is re-exported from the internal package
+func UnmarshalGraphQL(data []byte, v interface{}) error {
+	return jsonutil.UnmarshalGraphQL(data, v)
+}
+
 type operationType uint8
 
 const (

--- a/graphql.go
+++ b/graphql.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -22,6 +23,7 @@ type Client struct {
 	url             string // GraphQL server URL.
 	httpClient      *http.Client
 	requestModifier RequestModifier
+	debug           bool
 }
 
 // NewClient creates a GraphQL client targeting the specified GraphQL server URL.
@@ -93,20 +95,19 @@ func (c *Client) NamedMutateRaw(ctx context.Context, name string, m interface{},
 	return c.doRaw(ctx, mutationOperation, m, variables, append(options, OperationName(name))...)
 }
 
-// do executes a single GraphQL operation.
-// return raw message and error
-func (c *Client) doRaw(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, options ...Option) (*json.RawMessage, error) {
+// buildAndRequest the common method that builds and send graphql request
+func (c *Client) buildAndRequest(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, options ...Option) (*json.RawMessage, *http.Response, io.Reader, Errors) {
 	var query string
 	var err error
 	switch op {
 	case queryOperation:
-		query, err = constructQuery(v, variables, options...)
+		query, err = ConstructQuery(v, variables, options...)
 	case mutationOperation:
-		query, err = constructMutation(v, variables, options...)
+		query, err = ConstructMutation(v, variables, options...)
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, Errors{newError(ErrGraphQLEncode, err)}
 	}
 
 	in := struct {
@@ -119,12 +120,17 @@ func (c *Client) doRaw(ctx context.Context, op operationType, v interface{}, var
 	var buf bytes.Buffer
 	err = json.NewEncoder(&buf).Encode(in)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil, Errors{newError(ErrGraphQLEncode, err)}
 	}
 
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, &buf)
+	reqReader := bytes.NewReader(buf.Bytes())
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, reqReader)
 	if err != nil {
-		return nil, fmt.Errorf("problem constructing request: %w", err)
+		e := newError(ErrRequestError, fmt.Errorf("problem constructing request: %w", err))
+		if c.debug {
+			e = e.withRequest(request, reqReader)
+		}
+		return nil, nil, nil, Errors{e}
 	}
 	request.Header.Add("Content-Type", "application/json")
 
@@ -133,113 +139,119 @@ func (c *Client) doRaw(ctx context.Context, op operationType, v interface{}, var
 	}
 
 	resp, err := c.httpClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
-		return nil, fmt.Errorf("non-200 OK status code: %v body: %q", resp.Status, body)
-	}
-	var out struct {
-		Data   *json.RawMessage
-		Errors Errors
-	}
-	err = json.NewDecoder(resp.Body).Decode(&out)
-	if err != nil {
-		// TODO: Consider including response body in returned error, if deemed helpful.
-		return nil, err
-	}
 
-	if len(out.Errors) > 0 {
-		return out.Data, out.Errors
-	}
-
-	return out.Data, nil
-}
-
-// do executes a single GraphQL operation and unmarshal json.
-func (c *Client) do(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, options ...Option) error {
-	var query string
-	var err error
-	switch op {
-	case queryOperation:
-		query, err = constructQuery(v, variables, options...)
-	case mutationOperation:
-		query, err = constructMutation(v, variables, options...)
+	if c.debug {
+		reqReader.Seek(0, io.SeekStart)
 	}
 
 	if err != nil {
-		return err
-	}
-
-	in := struct {
-		Query     string                 `json:"query"`
-		Variables map[string]interface{} `json:"variables,omitempty"`
-	}{
-		Query:     query,
-		Variables: variables,
-	}
-	var buf bytes.Buffer
-	err = json.NewEncoder(&buf).Encode(in)
-	if err != nil {
-		return err
-	}
-
-	request, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, &buf)
-	if err != nil {
-		return fmt.Errorf("problem constructing request: %w", err)
-	}
-	request.Header.Add("Content-Type", "application/json")
-
-	if c.requestModifier != nil {
-		c.requestModifier(request)
-	}
-
-	resp, err := c.httpClient.Do(request)
-	if err != nil {
-		return err
+		e := newError(ErrRequestError, err)
+		if c.debug {
+			e = e.withRequest(request, reqReader)
+		}
+		return nil, nil, nil, Errors{e}
 	}
 	defer resp.Body.Close()
 
 	r := resp.Body
+
 	if resp.Header.Get("Content-Encoding") == "gzip" {
-		r, err = gzip.NewReader(r)
+		gr, err := gzip.NewReader(r)
 		if err != nil {
-			return fmt.Errorf("problem trying to create gzip reader: %w", err)
+			return nil, nil, nil, Errors{newError(ErrJsonDecode, fmt.Errorf("problem trying to create gzip reader: %w", err))}
 		}
-		defer r.Close()
+		defer gr.Close()
+		r = gr
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(r)
-		return fmt.Errorf("non-200 OK status code: %v body: %q", resp.Status, body)
+		body, _ := ioutil.ReadAll(resp.Body)
+		err := newError(ErrRequestError, fmt.Errorf("%v; body: %q", resp.Status, body))
+
+		if c.debug {
+			err = err.withRequest(request, reqReader)
+		}
+		return nil, nil, nil, Errors{err}
 	}
+
 	var out struct {
 		Data   *json.RawMessage
 		Errors Errors
 	}
 
-	err = json.NewDecoder(r).Decode(&out)
-	if err != nil {
-		// TODO: Consider including response body in returned error, if deemed helpful.
-		return err
-	}
-	if out.Data != nil {
-		err := jsonutil.UnmarshalGraphQL(*out.Data, v)
+	// copy the response reader for debugging
+	var respReader *bytes.Reader
+	if c.debug {
+		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			// TODO: Consider including response body in returned error, if deemed helpful.
-			return err
+			return nil, nil, nil, Errors{newError(ErrJsonDecode, err)}
+		}
+		respReader = bytes.NewReader(body)
+		r = io.NopCloser(respReader)
+	}
+
+	err = json.NewDecoder(r).Decode(&out)
+
+	if c.debug {
+		respReader.Seek(0, io.SeekStart)
+	}
+
+	if err != nil {
+		we := newError(ErrJsonDecode, err)
+		if c.debug {
+			we = we.withRequest(request, reqReader).
+				withResponse(resp, respReader)
+		}
+		return nil, nil, nil, Errors{we}
+	}
+
+	if len(out.Errors) > 0 {
+		if c.debug && (out.Errors[0].Extensions == nil || out.Errors[0].Extensions["request"] == nil) {
+			out.Errors[0] = out.Errors[0].
+				withRequest(request, reqReader).
+				withResponse(resp, respReader)
+		}
+
+		return out.Data, resp, respReader, out.Errors
+	}
+
+	return out.Data, resp, respReader, nil
+}
+
+// do executes a single GraphQL operation.
+// return raw message and error
+func (c *Client) doRaw(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, options ...Option) (*json.RawMessage, error) {
+	data, _, _, err := c.buildAndRequest(ctx, op, v, variables, options...)
+	if len(err) > 0 {
+		return data, err
+	}
+	return data, nil
+}
+
+// do executes a single GraphQL operation and unmarshal json.
+func (c *Client) do(ctx context.Context, op operationType, v interface{}, variables map[string]interface{}, options ...Option) error {
+	data, resp, respBuf, errs := c.buildAndRequest(ctx, op, v, variables, options...)
+
+	if data != nil {
+		err := jsonutil.UnmarshalGraphQL(*data, v)
+		if err != nil {
+			we := newError(ErrGraphQLDecode, err)
+			if c.debug {
+				we = we.withResponse(resp, respBuf)
+			}
+			errs = append(errs, we)
 		}
 	}
-	if len(out.Errors) > 0 {
-		return out.Errors
+
+	if len(errs) > 0 {
+		return errs
 	}
+
 	return nil
 }
 
 // Returns a copy of the client with the request modifier set. This allows you to reuse the same
-// TCP connection for multiple slghtly different requests to the same server
+// TCP connection for multiple slightly different requests to the same server
 // (i.e. different authentication headers for multitenant applications)
 func (c *Client) WithRequestModifier(f RequestModifier) *Client {
 	return &Client{
@@ -249,26 +261,99 @@ func (c *Client) WithRequestModifier(f RequestModifier) *Client {
 	}
 }
 
+// WithDebug enable debug mode to print internal error detail
+func (c *Client) WithDebug(debug bool) *Client {
+	return &Client{
+		url:             c.url,
+		httpClient:      c.httpClient,
+		requestModifier: c.requestModifier,
+		debug:           debug,
+	}
+}
+
 // errors represents the "errors" array in a response from a GraphQL server.
 // If returned via error interface, the slice is expected to contain at least 1 element.
 //
 // Specification: https://facebook.github.io/graphql/#sec-Errors.
-type Errors []struct {
-	Message    string
-	Extensions map[string]interface{}
+type Errors []Error
+
+type Error struct {
+	Message    string                 `json:"message"`
+	Extensions map[string]interface{} `json:"extensions"`
 	Locations  []struct {
-		Line   int
-		Column int
-	}
+		Line   int `json:"line"`
+		Column int `json:"column"`
+	} `json:"locations"`
+}
+
+// Error implements error interface.
+func (e Error) Error() string {
+	return fmt.Sprintf("Message: %s, Locations: %+v", e.Message, e.Locations)
 }
 
 // Error implements error interface.
 func (e Errors) Error() string {
 	b := strings.Builder{}
 	for _, err := range e {
-		b.WriteString(fmt.Sprintf("Message: %s, Locations: %+v", err.Message, err.Locations))
+		b.WriteString(err.Error())
 	}
 	return b.String()
+}
+
+func (e Error) getInternalExtension() map[string]interface{} {
+	if e.Extensions == nil {
+		return make(map[string]interface{})
+	}
+
+	if ex, ok := e.Extensions["internal"]; ok {
+		return ex.(map[string]interface{})
+	}
+
+	return make(map[string]interface{})
+}
+
+func newError(code string, err error) Error {
+	return Error{
+		Message: err.Error(),
+		Extensions: map[string]interface{}{
+			"code": code,
+		},
+	}
+}
+
+func (e Error) withRequest(req *http.Request, bodyReader io.Reader) Error {
+	internal := e.getInternalExtension()
+	bodyBytes, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		internal["error"] = err
+	} else {
+		internal["request"] = map[string]interface{}{
+			"headers": req.Header,
+			"body":    string(bodyBytes),
+		}
+	}
+
+	if e.Extensions == nil {
+		e.Extensions = make(map[string]interface{})
+	}
+	e.Extensions["internal"] = internal
+	return e
+}
+
+func (e Error) withResponse(res *http.Response, bodyReader io.Reader) Error {
+	internal := e.getInternalExtension()
+	bodyBytes, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		internal["error"] = err
+	} else {
+		internal["response"] = map[string]interface{}{
+			"headers": res.Header,
+			"body":    string(bodyBytes),
+		}
+	}
+
+	e.Extensions["internal"] = internal
+	return e
 }
 
 type operationType uint8
@@ -277,4 +362,10 @@ const (
 	queryOperation operationType = iota
 	mutationOperation
 	// subscriptionOperation // Unused.
+
+	ErrRequestError  = "request_error"
+	ErrJsonEncode    = "json_encode_error"
+	ErrJsonDecode    = "json_decode_error"
+	ErrGraphQLEncode = "graphql_encode_error"
+	ErrGraphQLDecode = "graphql_decode_error"
 )

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3,6 +3,7 @@ package graphql_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -119,6 +120,21 @@ func TestClient_Query_partialDataRawQueryWithErrorResponse(t *testing.T) {
 	if q.Node2 != nil {
 		t.Errorf("got non-nil q.Node2: %v, want: nil\n", *q.Node2)
 	}
+
+	// test internal error data
+	client = client.WithDebug(true)
+	err = client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if !errors.As(err, &graphql.Errors{}) {
+		t.Errorf("the error type should be graphql.Errors")
+	}
+
+	gqlErr := err.(graphql.Errors)
+	if got, want := gqlErr[0].Message, `Could not resolve to a node with the global id of 'NotExist'`; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
 }
 
 func TestClient_Query_noDataWithErrorResponse(t *testing.T) {
@@ -161,6 +177,29 @@ func TestClient_Query_noDataWithErrorResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
+
+	// test internal error data
+	client = client.WithDebug(true)
+	err = client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if !errors.As(err, &graphql.Errors{}) {
+		t.Errorf("the error type should be graphql.Errors")
+	}
+
+	gqlErr := err.(graphql.Errors)
+	if got, want := gqlErr[0].Message, `Field 'user' is missing required arguments: login`; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+
+	interErr := gqlErr[0].Extensions["internal"].(map[string]interface{})
+
+	if got, want := interErr["request"].(map[string]interface{})["body"], "{\"query\":\"{user{name}}\"}\n"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	b, _ := json.Marshal(gqlErr)
+	panic(string(b))
 }
 
 func TestClient_Query_errorStatusCode(t *testing.T) {
@@ -179,11 +218,41 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
-	if got, want := err.Error(), `non-200 OK status code: 500 Internal Server Error body: "important message\n"`; got != want {
+	if got, want := err.Error(), `Message: 500 Internal Server Error; body: "important message\n", Locations: []`; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if q.User.Name != "" {
 		t.Errorf("got non-empty q.User.Name: %v", q.User.Name)
+	}
+
+	gqlErr := err.(graphql.Errors)
+	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	if _, ok := gqlErr[0].Extensions["internal"]; ok {
+		t.Errorf("expected empty internal error")
+	}
+
+	// test internal error data
+	client = client.WithDebug(true)
+	err = client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if !errors.As(err, &graphql.Errors{}) {
+		t.Errorf("the error type should be graphql.Errors")
+	}
+	gqlErr = err.(graphql.Errors)
+	if got, want := gqlErr[0].Message, `500 Internal Server Error; body: "important message\n"`; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	interErr := gqlErr[0].Extensions["internal"].(map[string]interface{})
+
+	if got, want := interErr["request"].(map[string]interface{})["body"], "{\"query\":\"{user{name}}\"}\n"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
 	}
 }
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -198,8 +198,6 @@ func TestClient_Query_noDataWithErrorResponse(t *testing.T) {
 	if got, want := interErr["request"].(map[string]interface{})["body"], "{\"query\":\"{user{name}}\"}\n"; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
-	b, _ := json.Marshal(gqlErr)
-	panic(string(b))
 }
 
 func TestClient_Query_errorStatusCode(t *testing.T) {

--- a/query.go
+++ b/query.go
@@ -43,7 +43,8 @@ func constructOptions(options []Option) (*constructOptionsOutput, error) {
 	return output, nil
 }
 
-func constructQuery(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
+// ConstructQuery build GraphQL query string from struct and variables
+func ConstructQuery(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
 	query := query(v)
 
 	optionsOutput, err := constructOptions(options)
@@ -62,7 +63,8 @@ func constructQuery(v interface{}, variables map[string]interface{}, options ...
 	return fmt.Sprintf("query %s%s%s", optionsOutput.operationName, optionsOutput.OperationDirectivesString(), query), nil
 }
 
-func constructMutation(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
+// ConstructQuery build GraphQL mutation string from struct and variables
+func ConstructMutation(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
 	query := query(v)
 	optionsOutput, err := constructOptions(options)
 	if err != nil {
@@ -79,7 +81,8 @@ func constructMutation(v interface{}, variables map[string]interface{}, options 
 	return fmt.Sprintf("mutation %s%s%s", optionsOutput.operationName, optionsOutput.OperationDirectivesString(), query), nil
 }
 
-func constructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
+// ConstructSubscription build GraphQL subscription string from struct and variables
+func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
 	query := query(v)
 	optionsOutput, err := constructOptions(options)
 	if err != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -330,7 +330,7 @@ func TestConstructQuery(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got, err := constructQuery(tc.inV, tc.inVariables, tc.options...)
+		got, err := ConstructQuery(tc.inV, tc.inVariables, tc.options...)
 		if err != nil {
 			t.Error(err)
 		} else if got != tc.want {
@@ -386,7 +386,7 @@ func TestConstructMutation(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got, err := constructMutation(tc.inV, tc.inVariables)
+		got, err := ConstructMutation(tc.inV, tc.inVariables)
 		if err != nil {
 			t.Error(err)
 		} else if got != tc.want {
@@ -621,7 +621,7 @@ func TestConstructSubscription(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got, err := constructSubscription(tc.inV, tc.inVariables, OperationName(tc.name))
+		got, err := ConstructSubscription(tc.inV, tc.inVariables, OperationName(tc.name))
 		if err != nil {
 			t.Error(err)
 		} else if got != tc.want {

--- a/subscription.go
+++ b/subscription.go
@@ -303,7 +303,7 @@ func (sc *SubscriptionClient) SubscribeRaw(query string, variables map[string]in
 }
 
 func (sc *SubscriptionClient) do(v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error, options ...Option) (string, error) {
-	query, err := constructSubscription(v, variables, options...)
+	query, err := ConstructSubscription(v, variables, options...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Enable debug mode with the `WithDebug` function. If the request is failed, the request and response information will be included in the `extensions[].internal` property.

```json
{
	"errors": [
		{
			"message":"Field 'user' is missing required arguments: login",
			"extensions": {
				"internal": {
					"request": {
						"body":"{\"query\":\"{user{name}}\"}",
						"headers": {
							"Content-Type": ["application/json"]
						}
					},
					"response": {
						"body":"{\"errors\": [{\"message\": \"Field 'user' is missing required arguments: login\",\"locations\": [{\"line\": 7,\"column\": 3}]}]}",
						"headers": {
							"Content-Type": ["application/json"]
						}
					}
				}
			},
			"locations": [
				{
					"line":7,
					"column":3
				}
			]
		}
	]
}
```

Because the GraphQL query string is generated in runtime using reflection, it isn't really safe. To assure the GraphQL query is expected, it's necessary to write some unit tests for query construction.

```go
// ConstructQuery build GraphQL query string from struct and variables
func ConstructQuery(v interface{}, variables map[string]interface{}, options ...Option) (string, error)

// ConstructQuery build GraphQL mutation string from struct and variables
func ConstructMutation(v interface{}, variables map[string]interface{}, options ...Option) (string, error)

// ConstructSubscription build GraphQL subscription string from struct and variables
func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) 

// UnmarshalGraphQL parses the JSON-encoded GraphQL response data and stores
// the result in the GraphQL query data structure pointed to by v.
func UnmarshalGraphQL(data []byte, v interface{}) error 
```