### PR TITLE
Skip field with hyphen graphql tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
 		- [Simple Query](#simple-query)
 		- [Arguments and Variables](#arguments-and-variables)
 		- [Custom scalar tag](#custom-scalar-tag)
+		- [Skip GraphQL field](#skip-graphql-field)
 		- [Inline Fragments](#inline-fragments)
 		- [Mutations](#mutations)
 			- [Mutations Without Fields](#mutations-without-fields)
@@ -215,6 +216,22 @@ struct {
 
 // Output
 // { viewer }
+```
+
+### Skip GraphQL field
+
+```go
+struct {
+  Viewer struct {
+		ID         interface{} `graphql:"-"`
+		Login      string
+		CreatedAt  time.Time `graphql:"-"`
+		DatabaseID int
+  }
+}
+
+// Output
+// {viewer{login,databaseId}}
 ```
 
 ### Inline Fragments

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -282,6 +282,39 @@ func TestClient_Query_emptyVariables(t *testing.T) {
 	}
 }
 
+// Test ignored field
+// handled no differently than a nil variables map.
+func TestClient_Query_ignoreFields(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+		body := mustRead(req.Body)
+		if got, want := body, `{"query":"{user{id,name}}"}`+"\n"; got != want {
+			t.Errorf("got body: %v, want %v", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(w, `{"data": {"user": {"name": "Gopher"}}}`)
+	})
+	client := graphql.NewClient("/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
+
+	var q struct {
+		User struct {
+			ID      string `graphql:"id"`
+			Name    string `graphql:"name"`
+			Ignored string `graphql:"-"`
+		}
+	}
+	err := client.Query(context.Background(), &q, map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := q.User.Name, "Gopher"; got != want {
+		t.Errorf("got q.User.Name: %q, want: %q", got, want)
+	}
+	if got, want := q.User.Ignored, ""; got != want {
+		t.Errorf("got q.User.Ignored: %q, want: %q", got, want)
+	}
+}
+
 // localRoundTripper is an http.RoundTripper that executes HTTP transactions
 // by using handler directly, instead of going over an HTTP connection.
 type localRoundTripper struct {

--- a/query.go
+++ b/query.go
@@ -177,12 +177,19 @@ func writeQuery(w io.Writer, t reflect.Type, v reflect.Value, inline bool) {
 		if !inline {
 			io.WriteString(w, "{")
 		}
+		iter := 0
 		for i := 0; i < t.NumField(); i++ {
-			if i != 0 {
-				io.WriteString(w, ",")
-			}
 			f := t.Field(i)
 			value, ok := f.Tag.Lookup("graphql")
+			// Skip this field if the tag value is hyphen
+			if value == "-" {
+				continue
+			}
+			if iter != 0 {
+				io.WriteString(w, ",")
+			}
+			iter++
+
 			inlineField := f.Anonymous && !ok
 			if !inlineField {
 				if ok {

--- a/query_test.go
+++ b/query_test.go
@@ -328,6 +328,17 @@ func TestConstructQuery(t *testing.T) {
 			}{},
 			want: `{viewer}`,
 		},
+		{
+			inV: struct {
+				Viewer struct {
+					ID         interface{} `graphql:"-"`
+					Login      string
+					CreatedAt  time.Time `graphql:"-"`
+					DatabaseID int
+				}
+			}{},
+			want: `{viewer{login,databaseId}}`,
+		},
 	}
 	for _, tc := range tests {
 		got, err := ConstructQuery(tc.inV, tc.inVariables, tc.options...)


### PR DESCRIPTION
Skip GraphQL field with hyphen tag. Inspired from `encoding/json` library. 

```go
struct {
    Viewer struct {
	ID         interface{} `graphql:"-"`
	Login      string
	CreatedAt  time.Time `graphql:"-"`
	DatabaseID int
   }
}

// Output
// {viewer{login,databaseId}}
```
