### PR TITLE
added method to execute queries already pre-built

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -239,7 +239,9 @@ func (c *Client) do(ctx context.Context, op operationType, v interface{}, variab
 	return c.processResponse(v, data, resp, respBuf, errs)
 }
 
-func (c *Client) DoWithQuery(ctx context.Context, query string, v interface{}, variables map[string]interface{}, options ...Option) error {
+// Executes a pre-built query and unmarshals the response into v. Unlike the Query method you have to specify in the query the
+// fields that you want to receive as they are not inferred from v. This method is useful if you need to build the query dynamically.
+func (c *Client) Exec(ctx context.Context, query string, v interface{}, variables map[string]interface{}, options ...Option) error {
 	data, resp, respBuf, errs := c.request(ctx, query, variables, options...)
 	return c.processResponse(v, data, resp, respBuf, errs)
 }


### PR DESCRIPTION
This PR adds a method that allows you to execute pre-built queries. While using reflection to build queries is convenient as you get some resemblance of type safety it gets very cumbersome when you need to create queries semi-dynamically. For instance, imagine you are building a CLI tool to query data from a graphql endpoint and you want users to be able to narrow down the query by passing cli flags or something. In that case you could do something like:


``` go
        // filters would be built dynamically somehow from the command line flags
        filters := []string{
           `fieldA: {subfieldA: {_eq: "a"}}`,
           `fieldB: {_eq: "b"}`,
           ...
        }

	query := "query{something(where: {" + strings.Join(filters, ", ") + "}){id}}"
	res := struct {
		Somethings []Something
	}{}
	if err := client.DoWithQuery(ctx, query, &res, map[string]any{}); err != nil {
		panic(err)
	}
        ...
```

As far as I can tell with the current API there is no way of achieving this.