### PR TITLE
fix subscription hanging on error and add a stop subscription option inside the callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ You can programmatically stop the subscription while the client is running by us
 subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMessage, errValue error) error {
 	// ...
 	// return this error to stop the subscription in the callback
-	return graphql.ErrorSubscriptionStop()
+	return graphql.ErrSubscriptionStopped
 })
 
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
 		- [Subscription](#subscription)
 			- [Usage](#usage-1)
 			- [Subscribe](#subscribe)
+			- [Stop the subscription](#stop-the-subscription)
 			- [Authentication](#authentication-1)
 			- [Options](#options)
 			- [Events](#events)
@@ -490,13 +491,30 @@ subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMes
 	fmt.Println(query.Me.Name)
 
 	// Output: Luke Skywalker
+	return nil
+})
+
+if err != nil {
+	// Handle error.
+}
+```
+
+#### Stop the subscription
+
+You can programmatically stop the subscription while the client is running by using the `Unsubscribe` method, or returning a special error to stop it in the callback.
+
+```Go
+subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMessage, errValue error) error {
+	// ...
+	// return this error to stop the subscription in the callback
+	return graphql.ErrorSubscriptionStop()
 })
 
 if err != nil {
 	// Handle error.
 }
 
-// you can unsubscribe the subscription while the client is running
+// unsubscribe the subscription while the client is running with the subscription ID
 client.Unsubscribe(subscriptionId)
 ```
 
@@ -537,7 +555,7 @@ client.
 // OnConnected event is triggered when the websocket connected to GraphQL server sucessfully
 client.OnConnected(fn func())
 
-// OnDisconnected event is triggered when the websocket server was stil down after retry timeout
+// OnDisconnected event is triggered when the websocket client was disconnected
 client.OnDisconnected(fn func())
 
 // OnConnected event is triggered when there is any connection error. This is bottom exception handler level

--- a/example/subscription/client.go
+++ b/example/subscription/client.go
@@ -46,7 +46,7 @@ func startSubscription() error {
 		} `graphql:"helloSaid"`
 	}
 
-	_, err := client.Subscribe(sub, nil, func(data *json.RawMessage, err error) error {
+	subId, err := client.Subscribe(sub, nil, func(data *json.RawMessage, err error) error {
 
 		if err != nil {
 			log.Println(err)
@@ -64,6 +64,12 @@ func startSubscription() error {
 		panic(err)
 	}
 
+	// automatically unsubscribe after 10 seconds
+	go func() {
+		time.Sleep(10 * time.Second)
+		client.Unsubscribe(subId)
+	}()
+
 	return client.Run()
 }
 
@@ -71,8 +77,9 @@ func startSubscription() error {
 func startSendHello() {
 
 	client := graphql.NewClient(getServerEndpoint(), &http.Client{Transport: http.DefaultTransport})
-
-	for i := 0; i < 120; i++ {
+	// stop until the subscription client is connected
+	time.Sleep(time.Second)
+	for i := 0; i < 10; i++ {
 		/*
 			mutation ($msg: String!) {
 				sayHello(msg: $msg) {

--- a/example/subscription/main.go
+++ b/example/subscription/main.go
@@ -7,6 +7,6 @@ package main
 
 func main() {
 	go startServer()
-	go startSubscription()
-	startSendHello()
+	go startSendHello()
+	startSubscription()
 }

--- a/subscription.go
+++ b/subscription.go
@@ -51,6 +51,9 @@ const (
 	GQL_INTERNAL OperationMessageType = "internal"
 )
 
+// ErrSubscriptionStopped a special error which forces the subscription stop
+var ErrSubscriptionStopped = errors.New("subscription stopped")
+
 // OperationMessage represents a subscription operation message
 type OperationMessage struct {
 	ID      string               `json:"id,omitempty"`
@@ -504,7 +507,7 @@ func (sc *SubscriptionClient) Run() error {
 			return nil
 		case e := <-sc.errorChan:
 			// stop the subscription if the error has stop message
-			if e.Error() == string(GQL_STOP) {
+			if e == ErrSubscriptionStopped {
 				return nil
 			}
 
@@ -673,9 +676,4 @@ func newWebsocketConn(sc *SubscriptionClient) (WebsocketConn, error) {
 type WebsocketOptions struct {
 	// HTTPClient is used for the connection.
 	HTTPClient *http.Client
-}
-
-// ErrorSubscriptionStop creates a special error which forces the subscription to be stopped
-func ErrorSubscriptionStop() error {
-	return errors.New(string(GQL_STOP))
 }

--- a/subscription.go
+++ b/subscription.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -50,6 +51,7 @@ const (
 	GQL_INTERNAL OperationMessageType = "internal"
 )
 
+// OperationMessage represents a subscription operation message
 type OperationMessage struct {
 	ID      string               `json:"id,omitempty"`
 	Type    OperationMessageType `json:"type"`
@@ -197,7 +199,7 @@ func (sc *SubscriptionClient) OnConnected(fn func()) *SubscriptionClient {
 	return sc
 }
 
-// OnDisconnected event is triggered when the websocket server was still down after retry timeout
+// OnDisconnected event is triggered when the websocket client was disconnected
 func (sc *SubscriptionClient) OnDisconnected(fn func()) *SubscriptionClient {
 	sc.onDisconnected = fn
 	return sc
@@ -245,12 +247,19 @@ func (sc *SubscriptionClient) init() error {
 			}
 			return err
 		}
-		sc.printLog(err.Error()+". retry in second....", GQL_INTERNAL)
+		sc.printLog(fmt.Sprintf("%s. retry in second...", err.Error()), "client", GQL_INTERNAL)
 		time.Sleep(time.Second)
 	}
 }
 
-func (sc *SubscriptionClient) printLog(message interface{}, opType OperationMessageType) {
+func (sc *SubscriptionClient) writeJSON(v interface{}) error {
+	if sc.conn != nil {
+		return sc.conn.WriteJSON(v)
+	}
+	return nil
+}
+
+func (sc *SubscriptionClient) printLog(message interface{}, source string, opType OperationMessageType) {
 	if sc.log == nil {
 		return
 	}
@@ -260,7 +269,7 @@ func (sc *SubscriptionClient) printLog(message interface{}, opType OperationMess
 		}
 	}
 
-	sc.log(message)
+	sc.log(message, source)
 }
 
 func (sc *SubscriptionClient) sendConnectionInit() (err error) {
@@ -279,8 +288,8 @@ func (sc *SubscriptionClient) sendConnectionInit() (err error) {
 		Payload: bParams,
 	}
 
-	sc.printLog(msg, GQL_CONNECTION_INIT)
-	return sc.conn.WriteJSON(msg)
+	sc.printLog(msg, "client", GQL_CONNECTION_INIT)
+	return sc.writeJSON(msg)
 }
 
 // Subscribe sends start message to server and open a channel to receive data.
@@ -366,8 +375,8 @@ func (sc *SubscriptionClient) startSubscription(id string, sub *subscription) er
 		Payload: payload,
 	}
 
-	sc.printLog(msg, GQL_START)
-	if err := sc.conn.WriteJSON(msg); err != nil {
+	sc.printLog(msg, "client", GQL_START)
+	if err := sc.writeJSON(msg); err != nil {
 		return err
 	}
 
@@ -400,95 +409,112 @@ func (sc *SubscriptionClient) Run() error {
 	sc.subscribersMu.Unlock()
 
 	sc.setIsRunning(true)
+	go func() {
+		for atomic.LoadInt64(&sc.isRunning) > 0 {
+			select {
+			case <-sc.context.Done():
+				return
+			default:
+				var message OperationMessage
+				if err := sc.conn.ReadJSON(&message); err != nil {
+					// manual EOF check
+					if err == io.EOF || strings.Contains(err.Error(), "EOF") {
+						if err = sc.Reset(); err != nil {
+							sc.errorChan <- err
+							return
+						}
+					}
+					closeStatus := websocket.CloseStatus(err)
+					if closeStatus == websocket.StatusNormalClosure {
+						// close event from websocket client, exiting...
+						return
+					}
+					if closeStatus != -1 {
+						sc.printLog(fmt.Sprintf("%s. Retry connecting...", err), "client", GQL_INTERNAL)
+						if err = sc.Reset(); err != nil {
+							sc.errorChan <- err
+							return
+						}
+					}
+
+					if sc.onError != nil {
+						if err = sc.onError(sc, err); err != nil {
+							return
+						}
+					}
+					continue
+				}
+
+				switch message.Type {
+				case GQL_ERROR:
+					sc.printLog(message, "server", GQL_ERROR)
+					fallthrough
+				case GQL_DATA:
+					sc.printLog(message, "server", GQL_DATA)
+					id, err := uuid.Parse(message.ID)
+					if err != nil {
+						continue
+					}
+
+					sc.subscribersMu.Lock()
+					sub, ok := sc.subscriptions[id.String()]
+					sc.subscribersMu.Unlock()
+
+					if !ok {
+						continue
+					}
+					var out struct {
+						Data   *json.RawMessage
+						Errors Errors
+					}
+
+					err = json.Unmarshal(message.Payload, &out)
+					if err != nil {
+						go sub.handler(nil, err)
+						continue
+					}
+					if len(out.Errors) > 0 {
+						go sub.handler(nil, out.Errors)
+						continue
+					}
+
+					go sub.handler(out.Data, nil)
+				case GQL_CONNECTION_ERROR:
+					sc.printLog(message, "server", GQL_CONNECTION_ERROR)
+				case GQL_COMPLETE:
+					sc.printLog(message, "server", GQL_COMPLETE)
+					sc.Unsubscribe(message.ID)
+				case GQL_CONNECTION_KEEP_ALIVE:
+					sc.printLog(message, "server", GQL_CONNECTION_KEEP_ALIVE)
+				case GQL_CONNECTION_ACK:
+					sc.printLog(message, "server", GQL_CONNECTION_ACK)
+					if sc.onConnected != nil {
+						sc.onConnected()
+					}
+				default:
+					sc.printLog(message, "server", GQL_UNKNOWN)
+				}
+			}
+		}
+	}()
 
 	for atomic.LoadInt64(&sc.isRunning) > 0 {
 		select {
 		case <-sc.context.Done():
 			return nil
 		case e := <-sc.errorChan:
+			// stop the subscription if the error has stop message
+			if e.Error() == string(GQL_STOP) {
+				return nil
+			}
+
 			if sc.onError != nil {
 				if err := sc.onError(sc, e); err != nil {
 					return err
 				}
 			}
-		default:
-
-			var message OperationMessage
-			if err := sc.conn.ReadJSON(&message); err != nil {
-				// manual EOF check
-				if err == io.EOF || strings.Contains(err.Error(), "EOF") {
-					return sc.Reset()
-				}
-				closeStatus := websocket.CloseStatus(err)
-				if closeStatus == websocket.StatusNormalClosure {
-					// close event from websocket client, exiting...
-					return nil
-				}
-				if closeStatus != -1 {
-					sc.printLog(fmt.Sprintf("%s. Retry connecting...", err), GQL_INTERNAL)
-					return sc.Reset()
-				}
-
-				if sc.onError != nil {
-					if err = sc.onError(sc, err); err != nil {
-						return err
-					}
-				}
-				continue
-			}
-
-			switch message.Type {
-			case GQL_ERROR:
-				sc.printLog(message, GQL_ERROR)
-				fallthrough
-			case GQL_DATA:
-				sc.printLog(message, GQL_DATA)
-				id, err := uuid.Parse(message.ID)
-				if err != nil {
-					continue
-				}
-
-				sc.subscribersMu.Lock()
-				sub, ok := sc.subscriptions[id.String()]
-				sc.subscribersMu.Unlock()
-
-				if !ok {
-					continue
-				}
-				var out struct {
-					Data   *json.RawMessage
-					Errors Errors
-				}
-
-				err = json.Unmarshal(message.Payload, &out)
-				if err != nil {
-					go sub.handler(nil, err)
-					continue
-				}
-				if len(out.Errors) > 0 {
-					go sub.handler(nil, out.Errors)
-					continue
-				}
-
-				go sub.handler(out.Data, nil)
-			case GQL_CONNECTION_ERROR:
-				sc.printLog(message, GQL_CONNECTION_ERROR)
-			case GQL_COMPLETE:
-				sc.printLog(message, GQL_COMPLETE)
-				sc.Unsubscribe(message.ID)
-			case GQL_CONNECTION_KEEP_ALIVE:
-				sc.printLog(message, GQL_CONNECTION_KEEP_ALIVE)
-			case GQL_CONNECTION_ACK:
-				sc.printLog(message, GQL_CONNECTION_ACK)
-				if sc.onConnected != nil {
-					sc.onConnected()
-				}
-			default:
-				sc.printLog(message, GQL_UNKNOWN)
-			}
 		}
 	}
-
 	// if the running status is false, stop retrying
 	if atomic.LoadInt64(&sc.isRunning) == 0 {
 		return nil
@@ -509,7 +535,17 @@ func (sc *SubscriptionClient) Unsubscribe(id string) error {
 	}
 
 	delete(sc.subscriptions, id)
-	return sc.stopSubscription(id)
+	err := sc.stopSubscription(id)
+	if err != nil {
+		return err
+	}
+
+	// close the client if there is no running subscription
+	if len(sc.subscriptions) == 0 {
+		sc.printLog("no running subscription. exiting...", "client", GQL_INTERNAL)
+		return sc.Close()
+	}
+	return nil
 }
 
 func (sc *SubscriptionClient) stopSubscription(id string) error {
@@ -520,8 +556,8 @@ func (sc *SubscriptionClient) stopSubscription(id string) error {
 			Type: GQL_STOP,
 		}
 
-		sc.printLog(msg, GQL_STOP)
-		if err := sc.conn.WriteJSON(msg); err != nil {
+		sc.printLog(msg, "server", GQL_STOP)
+		if err := sc.writeJSON(msg); err != nil {
 			return err
 		}
 
@@ -531,14 +567,14 @@ func (sc *SubscriptionClient) stopSubscription(id string) error {
 }
 
 func (sc *SubscriptionClient) terminate() error {
-	if sc.conn != nil {
-		// send terminate message to the server
-		msg := OperationMessage{
-			Type: GQL_CONNECTION_TERMINATE,
-		}
+	// send terminate message to the server
+	msg := OperationMessage{
+		Type: GQL_CONNECTION_TERMINATE,
+	}
 
-		sc.printLog(msg, GQL_CONNECTION_TERMINATE)
-		return sc.conn.WriteJSON(msg)
+	if sc.conn != nil {
+		sc.printLog(msg, "client", GQL_CONNECTION_TERMINATE)
+		return sc.writeJSON(msg)
 	}
 
 	return nil
@@ -570,18 +606,20 @@ func (sc *SubscriptionClient) Reset() error {
 // Close closes all subscription channel and websocket as well
 func (sc *SubscriptionClient) Close() (err error) {
 	sc.setIsRunning(false)
-
 	for id := range sc.subscriptions {
 		if err = sc.Unsubscribe(id); err != nil {
 			sc.cancel()
-			return err
+			return
 		}
 	}
 
+	_ = sc.terminate()
 	if sc.conn != nil {
-		_ = sc.terminate()
 		err = sc.conn.Close()
 		sc.conn = nil
+		if sc.onDisconnected != nil {
+			sc.onDisconnected()
+		}
 	}
 	sc.cancel()
 
@@ -635,4 +673,9 @@ func newWebsocketConn(sc *SubscriptionClient) (WebsocketConn, error) {
 type WebsocketOptions struct {
 	// HTTPClient is used for the connection.
 	HTTPClient *http.Client
+}
+
+// ErrorSubscriptionStop creates a special error which forces the subscription to be stopped
+func ErrorSubscriptionStop() error {
+	return errors.New(string(GQL_STOP))
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"math/rand"
 	"net/http"
@@ -45,10 +46,7 @@ func subscription_setupClients() (*Client, *SubscriptionClient) {
 			"headers": map[string]string{
 				"foo": "bar",
 			},
-		}).WithLog(log.Println).
-		OnError(func(sc *SubscriptionClient, err error) error {
-			panic(err)
-		})
+		}).WithLog(log.Println)
 
 	return client, subscriptionClient
 }
@@ -185,6 +183,11 @@ func TestSubscriptionLifeCycle(t *testing.T) {
 	defer server.Shutdown(ctx)
 	defer cancel()
 
+	subscriptionClient.
+		OnError(func(sc *SubscriptionClient, err error) error {
+			return err
+		})
+
 	/*
 		subscription {
 			helloSaid {
@@ -217,16 +220,20 @@ func TestSubscriptionLifeCycle(t *testing.T) {
 			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
 		}
 
-		subscriptionClient.Close()
-		stop <- true
-		return nil
+		return errors.New("exit")
 	})
 
 	if err != nil {
 		t.Fatalf("got error: %v, want: nil", err)
 	}
 
-	go subscriptionClient.Run()
+	go func() {
+		if err := subscriptionClient.Run(); err == nil || err.Error() != "exit" {
+			(*t).Fatalf("got error: %v, want: exit", err)
+		}
+		stop <- true
+	}()
+
 	defer subscriptionClient.Close()
 
 	// wait until the subscription client connects to the server
@@ -256,4 +263,141 @@ func TestSubscriptionLifeCycle(t *testing.T) {
 	}
 
 	<-stop
+}
+
+func TestSubscriptionLifeCycle2(t *testing.T) {
+	server := subscription_setupServer()
+	client, subscriptionClient := subscription_setupClients()
+	msg := randomID()
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer server.Shutdown(ctx)
+	defer cancel()
+
+	subscriptionClient.
+		OnError(func(sc *SubscriptionClient, err error) error {
+			t.Fatalf("got error: %v, want: nil", err)
+			return err
+		}).
+		OnDisconnected(func() {
+			log.Println("disconnected")
+		})
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub struct {
+		HelloSaid struct {
+			ID      String
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data *json.RawMessage, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(*data))
+		e = json.Unmarshal(*data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub.HelloSaid.Message != String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub2 struct {
+		HelloSaid struct {
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	_, err = subscriptionClient.Subscribe(sub2, nil, func(data *json.RawMessage, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(*data))
+		e = json.Unmarshal(*data, &sub2)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub2.HelloSaid.Message != String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub2.HelloSaid.Message, msg)
+		}
+
+		return ErrorSubscriptionStop()
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		// wait until the subscription client connects to the server
+		time.Sleep(2 * time.Second)
+
+		// call a mutation request to send message to the subscription
+		/*
+			mutation ($msg: String!) {
+				sayHello(msg: $msg) {
+					id
+					msg
+				}
+			}
+		*/
+		var q struct {
+			SayHello struct {
+				ID  String
+				Msg String
+			} `graphql:"sayHello(msg: $msg)"`
+		}
+		variables := map[string]interface{}{
+			"msg": String(msg),
+		}
+		err = client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
+		if err != nil {
+			(*t).Fatalf("got error: %v, want: nil", err)
+		}
+
+		time.Sleep(time.Second)
+		subscriptionClient.Unsubscribe(subId1)
+	}()
+
+	defer subscriptionClient.Close()
+
+	if err := subscriptionClient.Run(); err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -357,7 +357,7 @@ func TestSubscriptionLifeCycle2(t *testing.T) {
 			t.Fatalf("subscription message does not match. got: %s, want: %s", sub2.HelloSaid.Message, msg)
 		}
 
-		return ErrorSubscriptionStop()
+		return ErrSubscriptionStopped
 	})
 
 	if err != nil {


### PR DESCRIPTION
- Fix the deadlock issue that the subscription client can't receive error events from the channel.
- Close the connection when there is no running subscription
- add a particular error that stops the subscription inside the callback 

```go
subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMessage, errValue error) error {
	// ...
	// return this error to stop the subscription in the callback
	return ErrSubscriptionStopped
})
```