### PR TITLE
introduce ExecRaw and change the output type of Raw methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
 
 **Status:** In active early research and development. The API will change when opportunities for improvement are discovered; it is not yet frozen.
 
+**Note**: Before v0.8.0, `QueryRaw`, `MutateRaw` and `Subscribe` methods return `*json.RawMessage`. This output type is redundant to be decoded. From v0.8.0, the output type is changed to `[]byte`.
+
 - [go-graphql-client](#go-graphql-client)
 	- [Installation](#installation)
 	- [Usage](#usage)
@@ -479,7 +481,7 @@ var subscription struct {
 Then call `client.Subscribe`, passing a pointer to it:
 
 ```Go
-subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMessage, errValue error) error {
+subscriptionId, err := client.Subscribe(&query, nil, func(dataValue []byte, errValue error) error {
 	if errValue != nil {
 		// handle error
 		// if returns error, it will failback to `onError` event
@@ -504,7 +506,7 @@ if err != nil {
 You can programmatically stop the subscription while the client is running by using the `Unsubscribe` method, or returning a special error to stop it in the callback.
 
 ```Go
-subscriptionId, err := client.Subscribe(&query, nil, func(dataValue *json.RawMessage, errValue error) error {
+subscriptionId, err := client.Subscribe(&query, nil, func(dataValue []byte, errValue error) error {
 	// ...
 	// return this error to stop the subscription in the callback
 	return graphql.ErrSubscriptionStopped
@@ -700,7 +702,7 @@ if err := client.Exec(ctx, query, &res, map[string]any{}); err != nil {
 }
 
 subscription := "subscription{something(where: {" + strings.Join(filters, ", ") + "}){id}}"
-subscriptionId, err := subscriptionClient.Exec(subscription, nil, func(dataValue *json.RawMessage, errValue error) error {
+subscriptionId, err := subscriptionClient.Exec(subscription, nil, func(dataValue []byte, errValue error) error {
 	if errValue != nil {
 		// handle error
 		// if returns error, it will failback to `onError` event
@@ -712,6 +714,22 @@ subscriptionId, err := subscriptionClient.Exec(subscription, nil, func(dataValue
 })
 ```
 
+If you prefer decoding JSON yourself, use `ExecRaw` instead.
+
+```Go
+query := `query{something(where: { foo: { _eq: "bar" }}){id}}`
+var res struct {
+	Somethings []Something `json:"something"`
+}
+
+raw, err := client.ExecRaw(ctx, query, map[string]any{}) 
+if err != nil {
+	panic(err)
+}
+
+err = json.Unmarshal(raw, &res)
+```
+
 ### With operation name (deprecated)
 
 Operation name is still on API decision plan https://github.com/shurcooL/graphql/issues/12. However, in my opinion separate methods are easier choice to avoid breaking changes
@@ -721,7 +739,7 @@ func (c *Client) NamedQuery(ctx context.Context, name string, q interface{}, var
 
 func (c *Client) NamedMutate(ctx context.Context, name string, q interface{}, variables map[string]interface{}) error
 
-func (sc *SubscriptionClient) NamedSubscribe(name string, v interface{}, variables map[string]interface{}, handler func(message *json.RawMessage, err error) error) (string, error)
+func (sc *SubscriptionClient) NamedSubscribe(name string, v interface{}, variables map[string]interface{}, handler func(message []byte, err error) error) (string, error)
 ```
 
 ### Raw bytes response
@@ -729,13 +747,13 @@ func (sc *SubscriptionClient) NamedSubscribe(name string, v interface{}, variabl
 In the case we developers want to decode JSON response ourself. Moreover, the default `UnmarshalGraphQL` function isn't ideal with complicated nested interfaces
 
 ```Go
-func (c *Client) QueryRaw(ctx context.Context, q interface{}, variables map[string]interface{}) (*json.RawMessage, error)
+func (c *Client) QueryRaw(ctx context.Context, q interface{}, variables map[string]interface{}) ([]byte, error)
 
-func (c *Client) MutateRaw(ctx context.Context, q interface{}, variables map[string]interface{}) (*json.RawMessage, error)
+func (c *Client) MutateRaw(ctx context.Context, q interface{}, variables map[string]interface{}) ([]byte, error)
 
-func (c *Client) NamedQueryRaw(ctx context.Context, name string, q interface{}, variables map[string]interface{}) (*json.RawMessage, error)
+func (c *Client) NamedQueryRaw(ctx context.Context, name string, q interface{}, variables map[string]interface{}) ([]byte, error)
 
-func (c *Client) NamedMutateRaw(ctx context.Context, name string, q interface{}, variables map[string]interface{}) (*json.RawMessage, error)
+func (c *Client) NamedMutateRaw(ctx context.Context, name string, q interface{}, variables map[string]interface{}) ([]byte, error)
 ```
 
 ### Multiple mutations with ordered map

--- a/doc.go
+++ b/doc.go
@@ -1,11 +1,9 @@
 // Package graphql provides a GraphQL client implementation.
 //
-// For more information, see package github.com/shurcooL/githubv4,
-// which is a specialized version targeting GitHub GraphQL API v4.
-// That package is driving the feature development.
+// For more information, see package github.com/hasura/go-graphql-client
 //
 // Status: In active early research and development. The API will change when
 // opportunities for improvement are discovered; it is not yet frozen.
 //
 // For now, see README for more details.
-package graphql // import "github.com/shurcooL/graphql"
+package graphql

--- a/example/subscription/client.go
+++ b/example/subscription/client.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -46,7 +45,7 @@ func startSubscription() error {
 		} `graphql:"helloSaid"`
 	}
 
-	subId, err := client.Subscribe(sub, nil, func(data *json.RawMessage, err error) error {
+	subId, err := client.Subscribe(sub, nil, func(data []byte, err error) error {
 
 		if err != nil {
 			log.Println(err)
@@ -56,7 +55,7 @@ func startSubscription() error {
 		if data == nil {
 			return nil
 		}
-		log.Println(string(*data))
+		log.Println(string(data))
 		return nil
 	})
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -203,14 +203,14 @@ func TestSubscriptionLifeCycle(t *testing.T) {
 		} `graphql:"helloSaid" json:"helloSaid"`
 	}
 
-	_, err := subscriptionClient.Subscribe(sub, nil, func(data *json.RawMessage, e error) error {
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil
 		}
 
-		log.Println("result", string(*data))
-		e = json.Unmarshal(*data, &sub)
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil
@@ -302,14 +302,14 @@ func TestSubscriptionLifeCycle2(t *testing.T) {
 		} `graphql:"helloSaid" json:"helloSaid"`
 	}
 
-	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data *json.RawMessage, e error) error {
+	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil
 		}
 
-		log.Println("result", string(*data))
-		e = json.Unmarshal(*data, &sub)
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil
@@ -340,14 +340,14 @@ func TestSubscriptionLifeCycle2(t *testing.T) {
 		} `graphql:"helloSaid" json:"helloSaid"`
 	}
 
-	_, err = subscriptionClient.Subscribe(sub2, nil, func(data *json.RawMessage, e error) error {
+	_, err = subscriptionClient.Subscribe(sub2, nil, func(data []byte, e error) error {
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil
 		}
 
-		log.Println("result", string(*data))
-		e = json.Unmarshal(*data, &sub2)
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub2)
 		if e != nil {
 			t.Fatalf("got error: %v, want: nil", e)
 			return nil


### PR DESCRIPTION
This PR adds `ExecRaw` method that returns a raw json message.

```Go
query := `query{something(where: { foo: { _eq: "bar" }}){id}}`
var res struct {
	Somethings []Something `json:"something"`
}

raw, err := client.ExecRaw(ctx, query, map[string]any{}) 
if err != nil {
	panic(err)
}

err = json.Unmarshal(raw, &res)
```

**Breaking change**: currently `QueryRaw`, `MutateRaw` and `Subscribe` methods return `*json.RawMessage`. This output type is redundant to be decoded. The output type should be changed to `[]byte`.

```Go
var subscription struct {
	Me struct {
		Name graphql.String
	}
}

subscriptionId, err := client.Subscribe(&query, nil, func(dataValue []byte, errValue error) error {
	if errValue != nil {
		// handle error
		// if returns error, it will failback to `onError` event
		return nil
	}
	data := query{}
	err := json.Unmarshal(dataValue, &data)

	fmt.Println(query.Me.Name)

	// Output: Luke Skywalker
	return nil
})

if err != nil {
	// Handle error.
}
```