### PR TITLE
Support nil argument type in query

### DIFF
--- a/query.go
+++ b/query.go
@@ -135,6 +135,11 @@ func queryArguments(variables map[string]interface{}) string {
 // value indicates whether t is a value (required) type or pointer (optional) type.
 // If value is true, then "!" is written at the end of t.
 func writeArgumentType(w io.Writer, t reflect.Type, value bool) {
+	if t == nil {
+		io.WriteString(w, "null")
+		return
+	}
+
 	if t.Kind() == reflect.Ptr {
 		// Pointer is an optional type, so no "!" at the end of the pointer's underlying type.
 		writeArgumentType(w, t.Elem(), false)

--- a/query_test.go
+++ b/query_test.go
@@ -658,6 +658,7 @@ func TestQueryArguments(t *testing.T) {
 	f64Val := float64(99.23)
 	bVal := true
 	sVal := "some string"
+	var nullVal interface{} = nil
 	tests := []struct {
 		in   map[string]interface{}
 		want string
@@ -701,6 +702,10 @@ func TestQueryArguments(t *testing.T) {
 		{
 			in:   map[string]interface{}{"a": sVal, "b": &sVal, "c": String("foo"), "d": NewString("bar")},
 			want: "$a:String!$b:String$c:String!$d:String",
+		},
+		{
+			in:   map[string]interface{}{"a": nullVal},
+			want: "$a:null",
 		},
 		{
 			in: map[string]interface{}{


### PR DESCRIPTION
Query for pagination with 'first'/'after' arguments can now support 'null' value for the first page. This avoids the need for two separate queries - without the 'after' argument to get the first page and with the 'after' argument for subsequent pages using the end cursor as the value.

An example follows:
```
vars := map[string]interface{}{
    "pageSize": 20,
    "cursorId": nil
}

var query struct {
    Users <type> `graphql:"users(first:$pageSize after:$cursorId)"`
}

if err := client.Query(ctx, &query, vars); err != nil { return err }
// Do something with first page

for query.Users.PageInfo.HasNextPage {
    vars["cursorId"] = query.PageInfo.EndCursor

    if err := client.Query(ctx, &query, vars); err != nil { return err }
    // Do something with next page
}
```