### PR TITLE
merge reset subscription logic into Run

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -321,7 +321,7 @@ type Error struct {
 
 // Error implements error interface.
 func (e Error) Error() string {
-	return fmt.Sprintf("Message: %s, Locations: %+v", e.Message, e.Locations)
+	return fmt.Sprintf("Message: %s, Locations: %+v, Extensions: %+v", e.Message, e.Locations, e.Extensions)
 }
 
 // Error implements error interface.

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -61,7 +61,7 @@ func TestClient_Query_partialDataWithErrorResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
-	if got, want := err.Error(), "Message: Could not resolve to a node with the global id of 'NotExist', Locations: [{Line:10 Column:4}]"; got != want {
+	if got, want := err.Error(), "Message: Could not resolve to a node with the global id of 'NotExist', Locations: [{Line:10 Column:4}], Extensions: map[]"; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 
@@ -111,7 +111,7 @@ func TestClient_Query_partialDataRawQueryWithErrorResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil\n")
 	}
-	if got, want := err.Error(), "Message: Could not resolve to a node with the global id of 'NotExist', Locations: [{Line:10 Column:4}]"; got != want {
+	if got, want := err.Error(), "Message: Could not resolve to a node with the global id of 'NotExist', Locations: [{Line:10 Column:4}], Extensions: map[]"; got != want {
 		t.Errorf("got error: %v, want: %v\n", got, want)
 	}
 	if q.Node1 == nil || string(q.Node1) != `{"id":"MDEyOklzc3VlQ29tbWVudDE2OTQwNzk0Ng=="}` {
@@ -166,7 +166,7 @@ func TestClient_Query_noDataWithErrorResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
-	if got, want := err.Error(), "Message: Field 'user' is missing required arguments: login, Locations: [{Line:7 Column:3}]"; got != want {
+	if got, want := err.Error(), "Message: Field 'user' is missing required arguments: login, Locations: [{Line:7 Column:3}], Extensions: map[]"; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if q.User.Name != "" {
@@ -216,7 +216,7 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
-	if got, want := err.Error(), `Message: 500 Internal Server Error; body: "important message\n", Locations: []`; got != want {
+	if got, want := err.Error(), `Message: 500 Internal Server Error; body: "important message\n", Locations: [], Extensions: map[code:request_error]`; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if q.User.Name != "" {

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -43,7 +43,7 @@ func (gws *graphqlWS) ConnectionInit(ctx *SubscriptionContext, connectionParams 
 }
 
 // Subscribe requests an graphql operation specified in the payload message
-func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub *Subscription) error {
+func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub Subscription) error {
 	if sub.GetStarted() {
 		return nil
 	}
@@ -63,13 +63,15 @@ func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub *Subscr
 	}
 
 	sub.SetStarted(true)
+	ctx.SetSubscription(id, &sub)
+
 	return nil
 }
 
 // Unsubscribe sends stop message to server and close subscription channel
 // The input parameter is subscription ID that is returned from Subscribe function
 func (gws *graphqlWS) Unsubscribe(ctx *SubscriptionContext, id string) error {
-	if ctx == nil || ctx.WebsocketConn == nil {
+	if ctx == nil || ctx.GetWebsocketConn() == nil {
 		return nil
 	}
 	sub := ctx.GetSubscription(id)
@@ -87,30 +89,23 @@ func (gws *graphqlWS) Unsubscribe(ctx *SubscriptionContext, id string) error {
 	}
 
 	err := ctx.Send(msg, GQLComplete)
-	if err != nil {
-		return err
-	}
-
 	// close the client if there is no running subscription
 	if len(ctx.GetSubscriptions()) == 0 {
 		ctx.Log("no running subscription. exiting...", "client", GQLInternal)
 		return ctx.Close()
 	}
 
-	return nil
+	return err
 }
 
 // OnMessage listens ongoing messages from server
-func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription *Subscription, message OperationMessage) {
+func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) {
 
 	switch message.Type {
 	case GQLError:
 		ctx.Log(message, "server", message.Type)
 	case GQLNext:
 		ctx.Log(message, "server", message.Type)
-		if subscription == nil {
-			return
-		}
 		var out struct {
 			Data   *json.RawMessage
 			Errors Errors

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -174,3 +174,105 @@ func TestGraphqlWS_Subscription(t *testing.T) {
 
 	<-stop
 }
+
+func TestGraphqlWS_SubscriptionRerun(t *testing.T) {
+	client, subscriptionClient := graphqlWS_setupClients()
+	msg := randomID()
+
+	subscriptionClient = subscriptionClient.
+		OnError(func(sc *SubscriptionClient, err error) error {
+			return err
+		})
+
+	/*
+		subscription {
+			user {
+				id
+				name
+			}
+		}
+	*/
+	var sub struct {
+		Users []struct {
+			ID   int    `graphql:"id"`
+			Name string `graphql:"name"`
+		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+	}
+
+	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		if err := subscriptionClient.Run(); err != nil {
+			(*t).Fatalf("got error: %v, want: nil", err)
+		}
+	}()
+
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	if err := waitHasuraService(60); err != nil {
+		t.Fatalf("failed to start hasura service: %s", err)
+	}
+
+	// call a mutation request to send message to the subscription
+	/*
+		mutation InsertUser($objects: [user_insert_input!]!) {
+			insert_user(objects: $objects) {
+				id
+				name
+			}
+		}
+	*/
+	var q struct {
+		InsertUser struct {
+			Returning []struct {
+				ID   int    `graphql:"id"`
+				Name string `graphql:"name"`
+			} `graphql:"returning"`
+		} `graphql:"insert_user(objects: $objects)"`
+	}
+	variables := map[string]interface{}{
+		"objects": []user_insert_input{
+			{
+				"name": msg,
+			},
+		},
+	}
+	err = client.Mutate(context.Background(), &q, variables, OperationName("InsertUser"))
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	time.Sleep(2 * time.Second)
+	go func() {
+		time.Sleep(2 * time.Second)
+		subscriptionClient.Unsubscribe(subId1)
+	}()
+
+	if err := subscriptionClient.Run(); err != nil {
+		(*t).Fatalf("got error: %v, want: nil", err)
+	}
+}


### PR DESCRIPTION
- merge the reset subscription logic into `Run` method to avoid unnecessary extra `Reset() -> Run()` calls.
- deprecate `Reset` method of the `SubscriptionClient`
- minor tweaks for atomic locks and data race fixes  