### PR TITLE
fix: prevent panic on late message after unsubscribed subscription

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -181,7 +181,10 @@ func (sc *SubscriptionContext) GetSubscription(id string) *Subscription {
 	if sc.subscriptions == nil {
 		return nil
 	}
-	sub, _ := sc.subscriptions[id]
+	sub, found := sc.subscriptions[id]
+	if !found {
+		return nil
+	}
 	return &sub
 }
 
@@ -617,6 +620,9 @@ func (sc *SubscriptionClient) Run() error {
 				}
 
 				sub := sc.context.GetSubscription(message.ID)
+				if sub == nil {
+					sub = &Subscription{}
+				}
 				go sc.protocol.OnMessage(sc.context, *sub, message)
 			}
 		}

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -110,6 +110,9 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 			Data   *json.RawMessage
 			Errors Errors
 		}
+		if subscription.handler == nil {
+			return
+		}
 
 		err := json.Unmarshal(message.Payload, &out)
 		if err != nil {

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -138,6 +138,9 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 			Data   *json.RawMessage
 			Errors Errors
 		}
+		if subscription.handler == nil {
+			return
+		}
 
 		err := json.Unmarshal(message.Payload, &out)
 		if err != nil {


### PR DESCRIPTION
When a message is received from a subscription that was just unsubscribed, a panic will be raised due to having an empty subscription that contains a nil handler.

Refactored `GetSubscription` to return nil when no subscription is found and added guard clause to prevent using it for `data` messages.