### PR TITLE
improve the subscription life cycle event and add new settings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           cd ./example/hasura
           docker-compose up -d
       - name: Run Go unit tests
-        run: go test -v -race -coverprofile=coverage.out ./...
+        run: go test -v -race -timeout 3m -coverprofile=coverage.out ./...
       - name: Go coverage format
         run: |
           go get github.com/boumenot/gocover-cobertura

--- a/README.md
+++ b/README.md
@@ -585,7 +585,12 @@ client.
 	// max size of response message
 	WithReadLimit(10*1024*1024).
 	// these operation event logs won't be printed
-	WithoutLogTypes(graphql.GQLData, graphql.GQLConnectionKeepAlive)
+	WithoutLogTypes(graphql.GQLData, graphql.GQLConnectionKeepAlive).
+	// the client should exit when all subscriptions were closed, default true
+	WithExitWhenNoSubscription(false).
+	// WithRetryStatusCodes allow retry the subscription connection when receiving one of these codes
+	// the input parameter can be number string or range, e.g 4000-5000 
+	WithRetryStatusCodes([]string{"4000", "4000-4050"})
 ```
 
 #### Subscription Protocols
@@ -629,6 +634,12 @@ client.OnDisconnected(fn func())
 // If this function is empty, or returns nil, the error is ignored
 // If returns error, the websocket connection will be terminated
 client.OnError(onError func(sc *SubscriptionClient, err error) error)
+
+// OnConnectionAlive event is triggered when the websocket receive a connection alive message (differs per protocol)
+client.OnConnectionAlive(fn func())
+
+// OnSubscriptionComplete event is triggered when the subscription receive a terminated message from the server
+client.OnSubscriptionComplete(fn func(sub Subscription))
 ```
 
 #### Custom HTTP Client

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ client.OnError(onError func(sc *SubscriptionClient, err error) error)
 // OnConnectionAlive event is triggered when the websocket receive a connection alive message (differs per protocol)
 client.OnConnectionAlive(fn func())
 
-// OnSubscriptionComplete event is triggered when the subscription receive a terminated message from the server
+// OnSubscriptionComplete event is triggered when the subscription receives a terminated message from the server
 client.OnSubscriptionComplete(fn func(sub Subscription))
 ```
 

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ client.
 	WithExitWhenNoSubscription(false).
 	// WithRetryStatusCodes allow retry the subscription connection when receiving one of these codes
 	// the input parameter can be number string or range, e.g 4000-5000 
-	WithRetryStatusCodes([]string{"4000", "4000-4050"})
+	WithRetryStatusCodes("4000", "4000-4050")
 ```
 
 #### Subscription Protocols

--- a/query.go
+++ b/query.go
@@ -88,22 +88,22 @@ func ConstructMutation(v interface{}, variables map[string]interface{}, options 
 }
 
 // ConstructSubscription build GraphQL subscription string from struct and variables
-func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, error) {
+func ConstructSubscription(v interface{}, variables map[string]interface{}, options ...Option) (string, string, error) {
 	query, err := query(v)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	optionsOutput, err := constructOptions(options)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if len(variables) > 0 {
-		return fmt.Sprintf("subscription %s(%s)%s%s", optionsOutput.operationName, queryArguments(variables), optionsOutput.OperationDirectivesString(), query), nil
+		return fmt.Sprintf("subscription %s(%s)%s%s", optionsOutput.operationName, queryArguments(variables), optionsOutput.OperationDirectivesString(), query), optionsOutput.operationName, nil
 	}
 	if optionsOutput.operationName == "" && len(optionsOutput.operationDirectives) == 0 {
-		return "subscription" + query, nil
+		return "subscription" + query, optionsOutput.operationName, nil
 	}
-	return fmt.Sprintf("subscription %s%s%s", optionsOutput.operationName, optionsOutput.OperationDirectivesString(), query), nil
+	return fmt.Sprintf("subscription %s%s%s", optionsOutput.operationName, optionsOutput.OperationDirectivesString(), query), optionsOutput.operationName, nil
 }
 
 // queryArguments constructs a minified arguments string for variables.

--- a/query_test.go
+++ b/query_test.go
@@ -635,11 +635,16 @@ func TestConstructSubscription(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got, err := ConstructSubscription(tc.inV, tc.inVariables, OperationName(tc.name))
+		got, gotName, err := ConstructSubscription(tc.inV, tc.inVariables, OperationName(tc.name))
 		if err != nil {
 			t.Error(err)
-		} else if got != tc.want {
-			t.Errorf("\ngot:  %q\nwant: %q\n", got, tc.want)
+		} else {
+			if got != tc.want {
+				t.Errorf("\ngot:  %q\nwant: %q\n", got, tc.want)
+			}
+			if gotName != tc.name {
+				t.Errorf("\ninvalid operation name \ngot:  %q\nwant: %q\n", gotName, tc.name)
+			}
 		}
 	}
 }

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -63,7 +63,7 @@ func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, sub Subscription) erro
 	}
 
 	sub.SetStatus(SubscriptionRunning)
-	ctx.SetSubscription(sub.id, &sub)
+	ctx.SetSubscription(sub.GetKey(), &sub)
 
 	return nil
 }
@@ -125,22 +125,22 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 	case GQLComplete:
 		ctx.Log(message, "server", message.Type)
 		sub := ctx.GetSubscription(message.ID)
-		if ctx.onSubscriptionComplete != nil {
+		if ctx.OnSubscriptionComplete != nil {
 			if sub == nil {
-				ctx.onSubscriptionComplete(Subscription{
+				ctx.OnSubscriptionComplete(Subscription{
 					id: message.ID,
 				})
 			} else {
-				ctx.onSubscriptionComplete(*sub)
+				ctx.OnSubscriptionComplete(*sub)
 			}
 		}
 		if sub != nil {
-			ctx.SetSubscription(message.ID, nil)
+			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLPing:
 		ctx.Log(message, "server", GQLPing)
-		if ctx.onConnectionAlive != nil {
-			ctx.onConnectionAlive()
+		if ctx.OnConnectionAlive != nil {
+			ctx.OnConnectionAlive()
 		}
 		// send pong response message back to the server
 		msg := OperationMessage{

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -43,8 +43,8 @@ func (gws *graphqlWS) ConnectionInit(ctx *SubscriptionContext, connectionParams 
 }
 
 // Subscribe requests an graphql operation specified in the payload message
-func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub Subscription) error {
-	if sub.GetStarted() {
+func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, sub Subscription) error {
+	if sub.GetStatus() == SubscriptionRunning {
 		return nil
 	}
 	payload, err := json.Marshal(sub.GetPayload())
@@ -53,7 +53,7 @@ func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub Subscri
 	}
 	// send start message to the server
 	msg := OperationMessage{
-		ID:      id,
+		ID:      sub.id,
 		Type:    GQLSubscribe,
 		Payload: payload,
 	}
@@ -62,48 +62,31 @@ func (gws *graphqlWS) Subscribe(ctx *SubscriptionContext, id string, sub Subscri
 		return err
 	}
 
-	sub.SetStarted(true)
-	ctx.SetSubscription(id, &sub)
+	sub.SetStatus(SubscriptionRunning)
+	ctx.SetSubscription(sub.id, &sub)
 
 	return nil
 }
 
 // Unsubscribe sends stop message to server and close subscription channel
 // The input parameter is subscription ID that is returned from Subscribe function
-func (gws *graphqlWS) Unsubscribe(ctx *SubscriptionContext, id string) error {
-	if ctx == nil || ctx.GetWebsocketConn() == nil {
-		return nil
-	}
-	sub := ctx.GetSubscription(id)
-
-	if sub == nil {
-		return fmt.Errorf("subscription id %s doesn't not exist", id)
-	}
-
-	ctx.SetSubscription(id, nil)
-
+func (gws *graphqlWS) Unsubscribe(ctx *SubscriptionContext, sub Subscription) error {
 	// send stop message to the server
 	msg := OperationMessage{
-		ID:   id,
+		ID:   sub.id,
 		Type: GQLComplete,
 	}
 
-	err := ctx.Send(msg, GQLComplete)
-	// close the client if there is no running subscription
-	if ctx.GetSubscriptionsLength() == 0 {
-		ctx.Log("no running subscription. exiting...", "client", GQLInternal)
-		return ctx.Close()
-	}
-
-	return err
+	return ctx.Send(msg, GQLComplete)
 }
 
 // OnMessage listens ongoing messages from server
-func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) {
+func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) error {
 
 	switch message.Type {
 	case GQLError:
 		ctx.Log(message, "server", message.Type)
+		return fmt.Errorf(string(message.Payload))
 	case GQLNext:
 		ctx.Log(message, "server", message.Type)
 		var out struct {
@@ -111,17 +94,17 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 			Errors Errors
 		}
 		if subscription.handler == nil {
-			return
+			return nil
 		}
 
 		err := json.Unmarshal(message.Payload, &out)
 		if err != nil {
 			subscription.handler(nil, err)
-			return
+			return nil
 		}
 		if len(out.Errors) > 0 {
 			subscription.handler(nil, out.Errors)
-			return
+			return nil
 		}
 
 		var outData []byte
@@ -132,7 +115,19 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 		subscription.handler(outData, nil)
 	case GQLComplete:
 		ctx.Log(message, "server", message.Type)
-		_ = gws.Unsubscribe(ctx, message.ID)
+		sub := ctx.GetSubscription(message.ID)
+		if ctx.onSubscriptionComplete != nil {
+			if sub == nil {
+				ctx.onSubscriptionComplete(Subscription{
+					id: message.ID,
+				})
+			} else {
+				ctx.onSubscriptionComplete(*sub)
+			}
+		}
+		if sub != nil {
+			ctx.SetSubscription(message.ID, nil)
+		}
 	case GQLPing:
 		ctx.Log(message, "server", GQLPing)
 		if ctx.onConnectionAlive != nil {
@@ -153,9 +148,9 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 		ctx.Log(message, "server", GQLConnectionAck)
 		ctx.SetAcknowledge(true)
 		for id, sub := range ctx.GetSubscriptions() {
-			if err := gws.Subscribe(ctx, id, sub); err != nil {
-				gws.Unsubscribe(ctx, id)
-				return
+			if err := gws.Subscribe(ctx, sub); err != nil {
+				ctx.Log(fmt.Sprintf("failed to subscribe: %s; id: %s; query: %s", err, id, sub.payload.Query), "client", GQLInternal)
+				return nil
 			}
 		}
 		if ctx.OnConnected != nil {
@@ -164,6 +159,8 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 	default:
 		ctx.Log(message, "server", GQLUnknown)
 	}
+
+	return nil
 }
 
 // Close terminates all subscriptions of the current websocket

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -84,7 +84,12 @@ func TestGraphqlWS_Subscription(t *testing.T) {
 	client, subscriptionClient := hasura_setupClients(GraphQLWS)
 	msg := randomID()
 
+	hasKeepAlive := false
+
 	subscriptionClient = subscriptionClient.
+		OnConnectionAlive(func() {
+			hasKeepAlive = true
+		}).
 		OnError(func(sc *SubscriptionClient, err error) error {
 			return err
 		})
@@ -173,6 +178,10 @@ func TestGraphqlWS_Subscription(t *testing.T) {
 	}
 
 	<-stop
+
+	if !hasKeepAlive {
+		t.Fatalf("expected OnConnectionAlive event, got none")
+	}
 }
 
 func TestGraphqlWS_SubscriptionRerun(t *testing.T) {

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"nhooyr.io/websocket"
 )
 
 const (
@@ -284,4 +286,82 @@ func TestGraphqlWS_SubscriptionRerun(t *testing.T) {
 	if err := subscriptionClient.Run(); err != nil {
 		(*t).Fatalf("got error: %v, want: nil", err)
 	}
+}
+
+func TestGraphQLWS_OnError(t *testing.T) {
+	stop := make(chan bool)
+
+	subscriptionClient := NewSubscriptionClient(fmt.Sprintf("%s/v1/graphql", hasuraTestHost)).
+		WithProtocol(GraphQLWS).
+		WithConnectionParams(map[string]interface{}{
+			"headers": map[string]string{
+				"x-hasura-admin-secret": "test",
+			},
+		}).WithLog(log.Println)
+
+	msg := randomID()
+
+	subscriptionClient = subscriptionClient.
+		OnConnected(func() {
+			log.Println("client connected")
+		}).
+		OnError(func(sc *SubscriptionClient, err error) error {
+			log.Println("OnError: ", err)
+			return err
+		})
+
+	/*
+		subscription {
+			user {
+				id
+				name
+			}
+		}
+	*/
+	var sub struct {
+		Users []struct {
+			ID   int    `graphql:"id"`
+			Name string `graphql:"name"`
+		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+	}
+
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		if err := subscriptionClient.Run(); err == nil || websocket.CloseStatus(err) != 4400 {
+			(*t).Fatalf("got error: %v, want: 4400", err)
+		}
+		stop <- true
+	}()
+
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	if err := waitHasuraService(60); err != nil {
+		t.Fatalf("failed to start hasura service: %s", err)
+	}
+
+	<-stop
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -3,178 +3,70 @@ package graphql
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log"
-	"math/rand"
-	"net/http"
+	"sync"
 	"testing"
 	"time"
-
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
-	"github.com/graph-gophers/graphql-transport-ws/graphqlws"
 )
 
-const schema = `
-schema {
-	subscription: Subscription
-	mutation: Mutation
-	query: Query
-}
-type Query {
-	hello: String!
-}
-type Subscription {
-	helloSaid(): HelloSaidEvent!
-}
-type Mutation {
-	sayHello(msg: String!): HelloSaidEvent!
-}
-type HelloSaidEvent {
-	id: String!
-	msg: String!
-}
-`
+func TestSubscription_LifeCycleEvents(t *testing.T) {
+	server := subscription_setupServer(8082)
+	client, subscriptionClient := subscription_setupClients(8082)
+	msg := randomID()
 
-func subscription_setupClients() (*Client, *SubscriptionClient) {
-	endpoint := "http://localhost:8081/graphql"
+	var lock sync.Mutex
+	subscriptionResults := []Subscription{}
+	wasConnected := false
+	wasDisconnected := false
+	addResult := func(s Subscription) int {
+		lock.Lock()
+		defer lock.Unlock()
+		subscriptionResults = append(subscriptionResults, s)
+		return len(subscriptionResults)
+	}
 
-	client := NewClient(endpoint, &http.Client{Transport: http.DefaultTransport})
+	fixtures := []struct {
+		Query        interface{}
+		Variables    map[string]interface{}
+		Subscription *Subscription
+	}{
+		{
+			Query: func() interface{} {
+				var t struct {
+					HelloSaid struct {
+						ID      String
+						Message String `graphql:"msg" json:"msg"`
+					} `graphql:"helloSaid" json:"helloSaid"`
+				}
 
-	subscriptionClient := NewSubscriptionClient(endpoint).
-		WithConnectionParams(map[string]interface{}{
-			"headers": map[string]string{
-				"foo": "bar",
+				return t
+			}(),
+			Variables: nil,
+			Subscription: &Subscription{
+				payload: GraphQLRequestPayload{
+					Query: "subscription{helloSaid{id,msg}}",
+				},
 			},
-		}).WithLog(log.Println)
+		},
+		{
+			Query: func() interface{} {
+				var t struct {
+					HelloSaid struct {
+						Message String `graphql:"msg" json:"msg"`
+					} `graphql:"helloSaid" json:"helloSaid"`
+				}
 
-	return client, subscriptionClient
-}
-
-func subscription_setupServer() *http.Server {
-
-	// init graphQL schema
-	s, err := graphql.ParseSchema(schema, newResolver())
-	if err != nil {
-		panic(err)
+				return t
+			}(),
+			Variables: nil,
+			Subscription: &Subscription{
+				payload: GraphQLRequestPayload{
+					Query: "subscription{helloSaid{msg}}",
+				},
+			},
+		},
 	}
 
-	// graphQL handler
-	mux := http.NewServeMux()
-	graphQLHandler := graphqlws.NewHandlerFunc(s, &relay.Handler{Schema: s})
-	mux.HandleFunc("/graphql", graphQLHandler)
-	server := &http.Server{Addr: ":8081", Handler: mux}
-
-	return server
-}
-
-type resolver struct {
-	helloSaidEvents     chan *helloSaidEvent
-	helloSaidSubscriber chan *helloSaidSubscriber
-}
-
-func newResolver() *resolver {
-	r := &resolver{
-		helloSaidEvents:     make(chan *helloSaidEvent),
-		helloSaidSubscriber: make(chan *helloSaidSubscriber),
-	}
-
-	go r.broadcastHelloSaid()
-
-	return r
-}
-
-func (r *resolver) Hello() string {
-	return "Hello world!"
-}
-
-func (r *resolver) SayHello(args struct{ Msg string }) *helloSaidEvent {
-	e := &helloSaidEvent{msg: args.Msg, id: randomID()}
-	go func() {
-		select {
-		case r.helloSaidEvents <- e:
-		case <-time.After(1 * time.Second):
-		}
-	}()
-	return e
-}
-
-type helloSaidSubscriber struct {
-	stop   <-chan struct{}
-	events chan<- *helloSaidEvent
-}
-
-func (r *resolver) broadcastHelloSaid() {
-	subscribers := map[string]*helloSaidSubscriber{}
-	unsubscribe := make(chan string)
-
-	// NOTE: subscribing and sending events are at odds.
-	for {
-		select {
-		case id := <-unsubscribe:
-			delete(subscribers, id)
-		case s := <-r.helloSaidSubscriber:
-			id := randomID()
-			log.Println("new client subscribed: ", id)
-			subscribers[id] = s
-		case e := <-r.helloSaidEvents:
-			for id, s := range subscribers {
-				go func(id string, s *helloSaidSubscriber) {
-					select {
-					case <-s.stop:
-						unsubscribe <- id
-						return
-					default:
-					}
-
-					select {
-					case <-s.stop:
-						unsubscribe <- id
-					case s.events <- e:
-					case <-time.After(time.Second):
-					}
-				}(id, s)
-			}
-		}
-	}
-}
-
-func (r *resolver) HelloSaid(ctx context.Context) <-chan *helloSaidEvent {
-	c := make(chan *helloSaidEvent)
-	// NOTE: this could take a while
-	r.helloSaidSubscriber <- &helloSaidSubscriber{events: c, stop: ctx.Done()}
-
-	return c
-}
-
-type helloSaidEvent struct {
-	id  string
-	msg string
-}
-
-func (r *helloSaidEvent) Msg() string {
-	return r.msg
-}
-
-func (r *helloSaidEvent) ID() string {
-	return r.id
-}
-
-func randomID() string {
-	var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
-
-	b := make([]rune, 16)
-	for i := range b {
-		b[i] = letter[rand.Intn(len(letter))]
-	}
-	return string(b)
-}
-
-func TestSubscriptionLifeCycle(t *testing.T) {
-	stop := make(chan bool)
-	server := subscription_setupServer()
-	client, subscriptionClient := subscription_setupClients()
-	msg := randomID()
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
 			log.Println(err)
@@ -185,185 +77,58 @@ func TestSubscriptionLifeCycle(t *testing.T) {
 	defer server.Shutdown(ctx)
 	defer cancel()
 
-	subscriptionClient.
-		OnError(func(sc *SubscriptionClient, err error) error {
-			return err
-		})
-
-	/*
-		subscription {
-			helloSaid {
-				id
-				msg
-			}
-		}
-	*/
-	var sub struct {
-		HelloSaid struct {
-			ID      String
-			Message String `graphql:"msg" json:"msg"`
-		} `graphql:"helloSaid" json:"helloSaid"`
-	}
-
-	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if sub.HelloSaid.Message != String(msg) {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
-		}
-
-		return errors.New("exit")
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	go func() {
-		if err := subscriptionClient.Run(); err == nil || err.Error() != "exit" {
-			(*t).Fatalf("got error: %v, want: exit", err)
-		}
-		stop <- true
-	}()
-
-	defer subscriptionClient.Close()
-
-	// wait until the subscription client connects to the server
-	time.Sleep(2 * time.Second)
-
-	// call a mutation request to send message to the subscription
-	/*
-		mutation ($msg: String!) {
-			sayHello(msg: $msg) {
-				id
-				msg
-			}
-		}
-	*/
-	var q struct {
-		SayHello struct {
-			ID  String
-			Msg String
-		} `graphql:"sayHello(msg: $msg)"`
-	}
-	variables := map[string]interface{}{
-		"msg": String(msg),
-	}
-	err = client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	<-stop
-}
-
-func TestSubscriptionLifeCycle2(t *testing.T) {
-	server := subscription_setupServer()
-	client, subscriptionClient := subscription_setupClients()
-	msg := randomID()
-	go func() {
-		if err := server.ListenAndServe(); err != nil {
-			log.Println(err)
-		}
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer server.Shutdown(ctx)
-	defer cancel()
-
-	subscriptionClient.
+	subscriptionClient = subscriptionClient.
+		WithExitWhenNoSubscription(false).
+		WithTimeout(3 * time.Second).
+		OnConnected(func() {
+			lock.Lock()
+			defer lock.Unlock()
+			log.Println("connected")
+			wasConnected = true
+		}).
 		OnError(func(sc *SubscriptionClient, err error) error {
 			t.Fatalf("got error: %v, want: nil", err)
 			return err
 		}).
 		OnDisconnected(func() {
+			lock.Lock()
+			defer lock.Unlock()
 			log.Println("disconnected")
+			wasDisconnected = true
+		}).
+		OnSubscriptionComplete(func(s Subscription) {
+			log.Println("OnSubscriptionComplete: ", s)
+			length := addResult(s)
+			if length == len(fixtures) {
+				log.Println("done, closing...")
+				subscriptionClient.Close()
+			}
 		})
-	/*
-		subscription {
-			helloSaid {
-				id
-				msg
+
+	for _, f := range fixtures {
+		id, err := subscriptionClient.Subscribe(f.Query, f.Variables, func(data []byte, e error) error {
+			lock.Lock()
+			defer lock.Unlock()
+			if e != nil {
+				t.Fatalf("got error: %v, want: nil", e)
+				return nil
 			}
-		}
-	*/
-	var sub struct {
-		HelloSaid struct {
-			ID      String
-			Message String `graphql:"msg" json:"msg"`
-		} `graphql:"helloSaid" json:"helloSaid"`
-	}
 
-	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if sub.HelloSaid.Message != String(msg) {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	/*
-		subscription {
-			helloSaid {
-				id
-				msg
+			log.Println("result", string(data))
+			e = json.Unmarshal(data, &f.Query)
+			if e != nil {
+				t.Fatalf("got error: %v, want: nil", e)
+				return nil
 			}
-		}
-	*/
-	var sub2 struct {
-		HelloSaid struct {
-			Message String `graphql:"msg" json:"msg"`
-		} `graphql:"helloSaid" json:"helloSaid"`
-	}
 
-	_, err = subscriptionClient.Subscribe(sub2, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
 			return nil
+		})
+
+		if err != nil {
+			t.Fatalf("got error: %v, want: nil", err)
 		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub2)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if sub2.HelloSaid.Message != String(msg) {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub2.HelloSaid.Message, msg)
-		}
-
-		return ErrSubscriptionStopped
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
+		f.Subscription.id = id
+		log.Printf("subscribed: %s; subscriptions %+v", id, subscriptionClient.context.subscriptions)
 	}
 
 	go func() {
@@ -388,167 +153,21 @@ func TestSubscriptionLifeCycle2(t *testing.T) {
 		variables := map[string]interface{}{
 			"msg": String(msg),
 		}
-		err = client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
-		if err != nil {
-			(*t).Fatalf("got error: %v, want: nil", err)
-		}
-
-		time.Sleep(time.Second)
-		subscriptionClient.Unsubscribe(subId1)
-	}()
-
-	defer subscriptionClient.Close()
-
-	if err := subscriptionClient.Run(); err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-}
-
-func TestSubscription_ResetClient(t *testing.T) {
-
-	stop := make(chan bool)
-	client, subscriptionClient := hasura_setupClients(SubscriptionsTransportWS)
-	msg := randomID()
-
-	subscriptionClient.
-		OnError(func(sc *SubscriptionClient, err error) error {
-			t.Fatalf("got error: %v, want: nil", err)
-			return err
-		}).
-		OnDisconnected(func() {
-			log.Println("disconnected")
-		})
-
-	/*
-		subscription {
-			user {
-				id
-				name
-			}
-		}
-	*/
-	var sub struct {
-		Users []struct {
-			ID   int    `graphql:"id"`
-			Name string `graphql:"name"`
-		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
-	}
-
-	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	defer subscriptionClient.Close()
-
-	// wait until the subscription client connects to the server
-	if err := waitHasuraService(60); err != nil {
-		t.Fatalf("failed to start hasura service: %s", err)
-	}
-
-	/*
-		subscription {
-			user {
-				id
-				name
-			}
-		}
-	*/
-	var sub2 struct {
-		Users []struct {
-			ID int `graphql:"id"`
-		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
-	}
-
-	subId2, err := subscriptionClient.Subscribe(sub2, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub2)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	go func() {
-
-		// call a mutation request to send message to the subscription
-		/*
-			mutation InsertUser($objects: [user_insert_input!]!) {
-				insert_user(objects: $objects) {
-					id
-					name
-				}
-			}
-		*/
-		var q struct {
-			InsertUser struct {
-				Returning []struct {
-					ID   int    `graphql:"id"`
-					Name string `graphql:"name"`
-				} `graphql:"returning"`
-			} `graphql:"insert_user(objects: $objects)"`
-		}
-		variables := map[string]interface{}{
-			"objects": []user_insert_input{
-				{
-					"name": msg,
-				},
-			},
-		}
-		err = client.Mutate(context.Background(), &q, variables, OperationName("InsertUser"))
-
+		err := client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
 		if err != nil {
 			(*t).Fatalf("got error: %v, want: nil", err)
 		}
 
 		time.Sleep(2 * time.Second)
-		// reset the subscription
-		log.Printf("resetting the subscription client...")
-		if err := subscriptionClient.Run(); err != nil {
-			(*t).Fatalf("failed to reset the subscription client. got error: %v, want: nil", err)
-		}
-		log.Printf("the second run was stopped")
-		stop <- true
-	}()
+		for _, f := range fixtures {
+			log.Println("unsubscribing ", f.Subscription.id)
+			if err := subscriptionClient.Unsubscribe(f.Subscription.id); err != nil {
+				log.Printf("subscriptions: %+v", subscriptionClient.context.subscriptions)
+				panic(err)
 
-	go func() {
-		time.Sleep(8 * time.Second)
-		subscriptionClient.Unsubscribe(subId1)
-		subscriptionClient.Unsubscribe(subId2)
+			}
+			time.Sleep(time.Second)
+		}
 	}()
 
 	defer subscriptionClient.Close()
@@ -557,5 +176,22 @@ func TestSubscription_ResetClient(t *testing.T) {
 		t.Fatalf("got error: %v, want: nil", err)
 	}
 
-	<-stop
+	if len(subscriptionResults) != len(fixtures) {
+		t.Fatalf("failed to listen OnSubscriptionComplete event. got %+v, want: %+v", len(subscriptionResults), len(fixtures))
+	}
+	for i, s := range subscriptionResults {
+		if s.id != fixtures[i].Subscription.id {
+			t.Fatalf("%d: subscription id not matched, got: %s, want: %s", i, s.GetPayload().Query, fixtures[i].Subscription.payload.Query)
+		}
+		if s.GetPayload().Query != fixtures[i].Subscription.payload.Query {
+			t.Fatalf("%d: query output not matched, got: %s, want: %s", i, s.GetPayload().Query, fixtures[i].Subscription.payload.Query)
+		}
+	}
+
+	if !wasConnected {
+		t.Fatalf("expected OnConnected event, got none")
+	}
+	if !wasDisconnected {
+		t.Fatalf("expected OnDisonnected event, got none")
+	}
 }

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -70,8 +70,8 @@ func (stw *subscriptionsTransportWS) ConnectionInit(ctx *SubscriptionContext, co
 }
 
 // Subscribe requests an graphql operation specified in the payload message
-func (stw *subscriptionsTransportWS) Subscribe(ctx *SubscriptionContext, id string, sub Subscription) error {
-	if sub.GetStarted() {
+func (stw *subscriptionsTransportWS) Subscribe(ctx *SubscriptionContext, sub Subscription) error {
+	if sub.GetStatus() == SubscriptionRunning {
 		return nil
 	}
 	payload, err := json.Marshal(sub.GetPayload())
@@ -80,7 +80,7 @@ func (stw *subscriptionsTransportWS) Subscribe(ctx *SubscriptionContext, id stri
 	}
 	// send start message to the server
 	msg := OperationMessage{
-		ID:      id,
+		ID:      sub.id,
 		Type:    GQLStart,
 		Payload: payload,
 	}
@@ -89,45 +89,26 @@ func (stw *subscriptionsTransportWS) Subscribe(ctx *SubscriptionContext, id stri
 		return err
 	}
 
-	sub.SetStarted(true)
-	ctx.SetSubscription(id, &sub)
+	sub.SetStatus(SubscriptionRunning)
+	ctx.SetSubscription(sub.id, &sub)
 
 	return nil
 }
 
 // Unsubscribe sends stop message to server and close subscription channel
 // The input parameter is subscription ID that is returned from Subscribe function
-func (stw *subscriptionsTransportWS) Unsubscribe(ctx *SubscriptionContext, id string) error {
-	if ctx == nil || ctx.GetWebsocketConn() == nil {
-		return nil
-	}
-	sub := ctx.GetSubscription(id)
-
-	if sub == nil {
-		return fmt.Errorf("subscription id %s doesn't not exist", id)
-	}
-
-	ctx.SetSubscription(id, nil)
-
+func (stw *subscriptionsTransportWS) Unsubscribe(ctx *SubscriptionContext, sub Subscription) error {
 	// send stop message to the server
 	msg := OperationMessage{
-		ID:   id,
+		ID:   sub.id,
 		Type: GQLStop,
 	}
 
-	err := ctx.Send(msg, GQLStop)
-
-	// close the client if there is no running subscription
-	if ctx.GetSubscriptionsLength() == 0 {
-		ctx.Log("no running subscription. exiting...", "client", GQLInternal)
-		return ctx.Close()
-	}
-
-	return err
+	return ctx.Send(msg, GQLStop)
 }
 
 // OnMessage listens ongoing messages from server
-func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) {
+func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) error {
 
 	switch message.Type {
 	case GQLError:
@@ -139,17 +120,17 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 			Errors Errors
 		}
 		if subscription.handler == nil {
-			return
+			return nil
 		}
 
 		err := json.Unmarshal(message.Payload, &out)
 		if err != nil {
 			subscription.handler(nil, err)
-			return
+			return nil
 		}
 		if len(out.Errors) > 0 {
 			subscription.handler(nil, out.Errors)
-			return
+			return nil
 		}
 
 		var outData []byte
@@ -160,11 +141,23 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 		subscription.handler(outData, nil)
 	case GQLConnectionError, "conn_err":
 		ctx.Log(message, "server", GQLConnectionError)
-		_ = stw.Close(ctx)
-		_ = ctx.Close()
+		return fmt.Errorf(string(message.Payload))
 	case GQLComplete:
 		ctx.Log(message, "server", GQLComplete)
-		_ = stw.Unsubscribe(ctx, message.ID)
+		sub := ctx.GetSubscription(message.ID)
+		if ctx.onSubscriptionComplete != nil {
+			if sub == nil {
+				ctx.onSubscriptionComplete(Subscription{
+					id: message.ID,
+				})
+			} else {
+				ctx.onSubscriptionComplete(*sub)
+				ctx.SetSubscription(message.ID, nil)
+			}
+		}
+		if sub != nil {
+			ctx.SetSubscription(message.ID, nil)
+		}
 	case GQLConnectionKeepAlive:
 		ctx.Log(message, "server", GQLConnectionKeepAlive)
 		if ctx.onConnectionAlive != nil {
@@ -177,9 +170,9 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 		ctx.SetAcknowledge(true)
 		subscriptions := ctx.GetSubscriptions()
 		for id, sub := range subscriptions {
-			if err := stw.Subscribe(ctx, id, sub); err != nil {
-				_ = stw.Unsubscribe(ctx, id)
-				return
+			if err := stw.Subscribe(ctx, sub); err != nil {
+				ctx.Log(fmt.Sprintf("failed to subscribe: %s; id: %s; query: %s", err, id, sub.payload.Query), "client", GQLInternal)
+				return nil
 			}
 		}
 		if ctx.OnConnected != nil {
@@ -188,6 +181,8 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 	default:
 		ctx.Log(message, "server", GQLUnknown)
 	}
+
+	return nil
 }
 
 // Close terminates all subscriptions of the current websocket

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -91,7 +91,7 @@ func (stw *subscriptionsTransportWS) Subscribe(ctx *SubscriptionContext, sub Sub
 	}
 
 	sub.SetStatus(SubscriptionRunning)
-	ctx.SetSubscription(sub.id, &sub)
+	ctx.SetSubscription(sub.GetKey(), &sub)
 
 	return nil
 }
@@ -167,23 +167,23 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 	case GQLComplete:
 		ctx.Log(message, "server", GQLComplete)
 		sub := ctx.GetSubscription(message.ID)
-		if ctx.onSubscriptionComplete != nil {
+		if ctx.OnSubscriptionComplete != nil {
 			if sub == nil {
-				ctx.onSubscriptionComplete(Subscription{
+				ctx.OnSubscriptionComplete(Subscription{
 					id: message.ID,
 				})
 			} else {
-				ctx.onSubscriptionComplete(*sub)
-				ctx.SetSubscription(message.ID, nil)
+				ctx.OnSubscriptionComplete(*sub)
+				ctx.SetSubscription(sub.GetKey(), nil)
 			}
 		}
 		if sub != nil {
-			ctx.SetSubscription(message.ID, nil)
+			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLConnectionKeepAlive:
 		ctx.Log(message, "server", GQLConnectionKeepAlive)
-		if ctx.onConnectionAlive != nil {
-			ctx.onConnectionAlive()
+		if ctx.OnConnectionAlive != nil {
+			ctx.OnConnectionAlive()
 		}
 	case GQLConnectionAck:
 		// Expected response to the ConnectionInit message from the client acknowledging a successful connection with the server.

--- a/subscriptions_transport_ws_test.go
+++ b/subscriptions_transport_ws_test.go
@@ -539,6 +539,32 @@ func TestTransportWS_ResetClient(t *testing.T) {
 		}
 
 		time.Sleep(2 * time.Second)
+
+		// test susbcription ids
+		sub1 := subscriptionClient.getContext().GetSubscription(subId1)
+		if sub1 == nil {
+			(*t).Fatalf("subscription 1 not found: %s", subId1)
+		} else {
+			if sub1.key != subId1 {
+				(*t).Fatalf("subscription key 1 not equal, got %s, want %s", subId1, sub1.key)
+			}
+			if sub1.id != subId1 {
+				(*t).Fatalf("subscription id 1 not equal, got %s, want %s", subId1, sub1.id)
+			}
+		}
+		sub2 := subscriptionClient.getContext().GetSubscription(subId2)
+		if sub2 == nil {
+			(*t).Fatalf("subscription 2 not found: %s", subId2)
+		} else {
+			if sub2.key != subId2 {
+				(*t).Fatalf("subscription id 2 not equal, got %s, want %s", subId2, sub2.key)
+			}
+
+			if sub2.id != subId2 {
+				(*t).Fatalf("subscription id 2 not equal, got %s, want %s", subId2, sub2.id)
+			}
+		}
+
 		// reset the subscription
 		log.Printf("resetting the subscription client...")
 		if err := subscriptionClient.Run(); err != nil {
@@ -550,6 +576,32 @@ func TestTransportWS_ResetClient(t *testing.T) {
 
 	go func() {
 		time.Sleep(8 * time.Second)
+
+		// test subscription ids
+		sub1 := subscriptionClient.getContext().GetSubscription(subId1)
+		if sub1 == nil {
+			(*t).Fatalf("subscription 1 not found: %s", subId1)
+		} else {
+			if sub1.key != subId1 {
+				(*t).Fatalf("subscription key 1 not equal, got %s, want %s", subId1, sub1.key)
+			}
+			if sub1.id == subId1 {
+				(*t).Fatalf("subscription id 1 should equal, got %s, want %s", subId1, sub1.id)
+			}
+		}
+		sub2 := subscriptionClient.getContext().GetSubscription(subId2)
+		if sub2 == nil {
+			(*t).Fatalf("subscription 2 not found: %s", subId2)
+		} else {
+			if sub2.key != subId2 {
+				(*t).Fatalf("subscription id 2 not equal, got %s, want %s", subId2, sub2.key)
+			}
+
+			if sub2.id == subId2 {
+				(*t).Fatalf("subscription id 2 should equal, got %s, want %s", subId2, sub2.id)
+			}
+		}
+
 		subscriptionClient.Unsubscribe(subId1)
 		subscriptionClient.Unsubscribe(subId2)
 	}()

--- a/subscriptions_transport_ws_test.go
+++ b/subscriptions_transport_ws_test.go
@@ -1,0 +1,636 @@
+package graphql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/graph-gophers/graphql-transport-ws/graphqlws"
+)
+
+const schema = `
+schema {
+	subscription: Subscription
+	mutation: Mutation
+	query: Query
+}
+type Query {
+	hello: String!
+}
+type Subscription {
+	helloSaid(): HelloSaidEvent!
+}
+type Mutation {
+	sayHello(msg: String!): HelloSaidEvent!
+}
+type HelloSaidEvent {
+	id: String!
+	msg: String!
+}
+`
+
+func subscription_setupClients(port int) (*Client, *SubscriptionClient) {
+	endpoint := fmt.Sprintf("http://localhost:%d/graphql", port)
+
+	client := NewClient(endpoint, &http.Client{Transport: http.DefaultTransport})
+
+	subscriptionClient := NewSubscriptionClient(endpoint).
+		WithConnectionParams(map[string]interface{}{
+			"headers": map[string]string{
+				"foo": "bar",
+			},
+		}).WithLog(log.Println)
+
+	return client, subscriptionClient
+}
+
+func subscription_setupServer(port int) *http.Server {
+
+	// init graphQL schema
+	s, err := graphql.ParseSchema(schema, newResolver())
+	if err != nil {
+		panic(err)
+	}
+
+	// graphQL handler
+	mux := http.NewServeMux()
+	graphQLHandler := graphqlws.NewHandlerFunc(s, &relay.Handler{Schema: s})
+	mux.HandleFunc("/graphql", graphQLHandler)
+	server := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+
+	return server
+}
+
+type resolver struct {
+	helloSaidEvents     chan *helloSaidEvent
+	helloSaidSubscriber chan *helloSaidSubscriber
+}
+
+func newResolver() *resolver {
+	r := &resolver{
+		helloSaidEvents:     make(chan *helloSaidEvent),
+		helloSaidSubscriber: make(chan *helloSaidSubscriber),
+	}
+
+	go r.broadcastHelloSaid()
+
+	return r
+}
+
+func (r *resolver) Hello() string {
+	return "Hello world!"
+}
+
+func (r *resolver) SayHello(args struct{ Msg string }) *helloSaidEvent {
+	e := &helloSaidEvent{msg: args.Msg, id: randomID()}
+	go func() {
+		select {
+		case r.helloSaidEvents <- e:
+		case <-time.After(1 * time.Second):
+		}
+	}()
+	return e
+}
+
+type helloSaidSubscriber struct {
+	stop   <-chan struct{}
+	events chan<- *helloSaidEvent
+}
+
+func (r *resolver) broadcastHelloSaid() {
+	subscribers := map[string]*helloSaidSubscriber{}
+	unsubscribe := make(chan string)
+
+	// NOTE: subscribing and sending events are at odds.
+	for {
+		select {
+		case id := <-unsubscribe:
+			delete(subscribers, id)
+		case s := <-r.helloSaidSubscriber:
+			id := randomID()
+			log.Println("new client subscribed: ", id)
+			subscribers[id] = s
+		case e := <-r.helloSaidEvents:
+			for id, s := range subscribers {
+				go func(id string, s *helloSaidSubscriber) {
+					select {
+					case <-s.stop:
+						unsubscribe <- id
+						return
+					default:
+					}
+
+					select {
+					case <-s.stop:
+						unsubscribe <- id
+					case s.events <- e:
+					case <-time.After(time.Second):
+					}
+				}(id, s)
+			}
+		}
+	}
+}
+
+func (r *resolver) HelloSaid(ctx context.Context) <-chan *helloSaidEvent {
+	c := make(chan *helloSaidEvent)
+	// NOTE: this could take a while
+	r.helloSaidSubscriber <- &helloSaidSubscriber{events: c, stop: ctx.Done()}
+
+	return c
+}
+
+type helloSaidEvent struct {
+	id  string
+	msg string
+}
+
+func (r *helloSaidEvent) Msg() string {
+	return r.msg
+}
+
+func (r *helloSaidEvent) ID() string {
+	return r.id
+}
+
+func randomID() string {
+	var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	b := make([]rune, 16)
+	for i := range b {
+		b[i] = letter[rand.Intn(len(letter))]
+	}
+	return string(b)
+}
+
+func TestTransportWS_basicTest(t *testing.T) {
+	stop := make(chan bool)
+	server := subscription_setupServer(8081)
+	client, subscriptionClient := subscription_setupClients(8081)
+	msg := randomID()
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer server.Shutdown(ctx)
+	defer cancel()
+
+	subscriptionClient.
+		OnError(func(sc *SubscriptionClient, err error) error {
+			return err
+		})
+
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub struct {
+		HelloSaid struct {
+			ID      String
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub.HelloSaid.Message != String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
+		}
+
+		return errors.New("exit")
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		if err := subscriptionClient.Run(); err == nil || err.Error() != "exit" {
+			(*t).Fatalf("got error: %v, want: exit", err)
+		}
+		stop <- true
+	}()
+
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	time.Sleep(2 * time.Second)
+
+	// call a mutation request to send message to the subscription
+	/*
+		mutation ($msg: String!) {
+			sayHello(msg: $msg) {
+				id
+				msg
+			}
+		}
+	*/
+	var q struct {
+		SayHello struct {
+			ID  String
+			Msg String
+		} `graphql:"sayHello(msg: $msg)"`
+	}
+	variables := map[string]interface{}{
+		"msg": String(msg),
+	}
+	err = client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	<-stop
+}
+
+func TestTransportWS_exitWhenNoSubscription(t *testing.T) {
+	server := subscription_setupServer(8084)
+	client, subscriptionClient := subscription_setupClients(8084)
+	msg := randomID()
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer server.Shutdown(ctx)
+	defer cancel()
+
+	subscriptionClient = subscriptionClient.
+		WithTimeout(3 * time.Second).
+		OnError(func(sc *SubscriptionClient, err error) error {
+			t.Fatalf("got error: %v, want: nil", err)
+			return err
+		}).
+		OnDisconnected(func() {
+			log.Println("disconnected")
+		})
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub struct {
+		HelloSaid struct {
+			ID      String
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub.HelloSaid.Message != String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub2 struct {
+		HelloSaid struct {
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	subId2, err := subscriptionClient.Subscribe(sub2, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub2)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub2.HelloSaid.Message != String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub2.HelloSaid.Message, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		// wait until the subscription client connects to the server
+		time.Sleep(2 * time.Second)
+
+		// call a mutation request to send message to the subscription
+		/*
+			mutation ($msg: String!) {
+				sayHello(msg: $msg) {
+					id
+					msg
+				}
+			}
+		*/
+		var q struct {
+			SayHello struct {
+				ID  String
+				Msg String
+			} `graphql:"sayHello(msg: $msg)"`
+		}
+		variables := map[string]interface{}{
+			"msg": String(msg),
+		}
+		err = client.Mutate(context.Background(), &q, variables, OperationName("SayHello"))
+		if err != nil {
+			(*t).Fatalf("got error: %v, want: nil", err)
+		}
+
+		time.Sleep(2 * time.Second)
+		subscriptionClient.Unsubscribe(subId1)
+		subscriptionClient.Unsubscribe(subId2)
+	}()
+
+	defer subscriptionClient.Close()
+
+	if err := subscriptionClient.Run(); err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+}
+
+func TestTransportWS_ResetClient(t *testing.T) {
+
+	stop := make(chan bool)
+	client, subscriptionClient := hasura_setupClients(SubscriptionsTransportWS)
+	msg := randomID()
+
+	subscriptionClient.
+		OnError(func(sc *SubscriptionClient, err error) error {
+			t.Fatalf("got error: %v, want: nil", err)
+			return err
+		}).
+		OnDisconnected(func() {
+			log.Println("disconnected")
+		})
+
+	/*
+		subscription {
+			user {
+				id
+				name
+			}
+		}
+	*/
+	var sub struct {
+		Users []struct {
+			ID   int    `graphql:"id"`
+			Name string `graphql:"name"`
+		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+	}
+
+	subId1, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	if err := waitHasuraService(60); err != nil {
+		t.Fatalf("failed to start hasura service: %s", err)
+	}
+
+	/*
+		subscription {
+			user {
+				id
+				name
+			}
+		}
+	*/
+	var sub2 struct {
+		Users []struct {
+			ID int `graphql:"id"`
+		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+	}
+
+	subId2, err := subscriptionClient.Subscribe(sub2, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub2)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+
+		// call a mutation request to send message to the subscription
+		/*
+			mutation InsertUser($objects: [user_insert_input!]!) {
+				insert_user(objects: $objects) {
+					id
+					name
+				}
+			}
+		*/
+		var q struct {
+			InsertUser struct {
+				Returning []struct {
+					ID   int    `graphql:"id"`
+					Name string `graphql:"name"`
+				} `graphql:"returning"`
+			} `graphql:"insert_user(objects: $objects)"`
+		}
+		variables := map[string]interface{}{
+			"objects": []user_insert_input{
+				{
+					"name": msg,
+				},
+			},
+		}
+		err = client.Mutate(context.Background(), &q, variables, OperationName("InsertUser"))
+
+		if err != nil {
+			(*t).Fatalf("got error: %v, want: nil", err)
+		}
+
+		time.Sleep(2 * time.Second)
+		// reset the subscription
+		log.Printf("resetting the subscription client...")
+		if err := subscriptionClient.Run(); err != nil {
+			(*t).Fatalf("failed to reset the subscription client. got error: %v, want: nil", err)
+		}
+		log.Printf("the second run was stopped")
+		stop <- true
+	}()
+
+	go func() {
+		time.Sleep(8 * time.Second)
+		subscriptionClient.Unsubscribe(subId1)
+		subscriptionClient.Unsubscribe(subId2)
+	}()
+
+	defer subscriptionClient.Close()
+
+	if err := subscriptionClient.Run(); err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	<-stop
+}
+
+func TestTransportWS_onDisconnected(t *testing.T) {
+	port := 8083
+	server := subscription_setupServer(port)
+	var wasConnected bool
+	disconnected := make(chan bool)
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	// init client
+	_, subscriptionClient := subscription_setupClients(port)
+	subscriptionClient = subscriptionClient.
+		WithTimeout(5 * time.Second).
+		OnError(func(sc *SubscriptionClient, err error) error {
+			panic(err)
+		}).
+		OnConnected(func() {
+			log.Println("OnConnected")
+			wasConnected = true
+		}).
+		OnDisconnected(func() {
+			log.Println("OnDisconnected")
+			disconnected <- true
+		})
+
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub struct {
+		HelloSaid struct {
+			ID      String
+			Message String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	// run client
+	go func() {
+		subscriptionClient.Run()
+	}()
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	time.Sleep(2 * time.Second)
+	if err := server.Close(); err != nil {
+		panic(err)
+	}
+
+	<-disconnected
+
+	if !wasConnected {
+		t.Fatal("the OnConnected event must be triggered")
+	}
+}


### PR DESCRIPTION
Fix https://github.com/hasura/go-graphql-client/issues/80
The PR improves the subscription client with a new event and settings

**Event**

```go
// OnSubscriptionComplete event is triggered when the subscription receives 
// a terminated message from the server
client.OnSubscriptionComplete(fn func(sub Subscription))
```

**Settings**
```go
client.
    // the client should exit when all subscriptions were closed, default true
    WithExitWhenNoSubscription(false).
    // WithRetryStatusCodes allow retry the subscription connection when receiving one of these codes
    // the input parameter can be number string or range, e.g 4000-5000 
    WithRetryStatusCodes([]string{"4000", "4000-4050"})
```
