### PR TITLE
feat: introduce QueryBuilder

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,197 @@
+package graphql
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+var (
+	// regular expression for the graphql variable name
+	// reference: https://spec.graphql.org/June2018/#sec-Names
+	regexVariableName = regexp.MustCompile(`\$([_A-Za-z][_0-9A-Za-z]*)`)
+
+	errBuildQueryRequired = errors.New("no graphql query to be built")
+)
+
+type queryBuilderItem struct {
+	query        string
+	binding      interface{}
+	requiredVars []string
+}
+
+// QueryBuilder is used to efficiently build dynamic queries and variables
+// It helps construct multiple queries to a single request that need to be conditionally added
+type QueryBuilder struct {
+	queries   []queryBuilderItem
+	variables map[string]interface{}
+}
+
+// QueryBinding the type alias of interface tuple
+// that includes the query string without fields and the binding type
+type QueryBinding [2]interface{}
+
+// NewQueryBuilder creates an empty QueryBuilder instance
+func NewQueryBuilder() QueryBuilder {
+	return QueryBuilder{
+		variables: make(map[string]interface{}),
+	}
+}
+
+// Query returns the new QueryBuilder with the inputted query
+func (b QueryBuilder) Query(query string, binding interface{}) QueryBuilder {
+	return QueryBuilder{
+		queries: append(b.queries, queryBuilderItem{
+			query,
+			binding,
+			findAllVariableNames(query),
+		}),
+		variables: b.variables,
+	}
+}
+
+// Variables returns the new QueryBuilder with the inputted variables
+func (b QueryBuilder) Variable(key string, value interface{}) QueryBuilder {
+	return QueryBuilder{
+		queries:   b.queries,
+		variables: setMapValue(b.variables, key, value),
+	}
+}
+
+// Variables returns the new QueryBuilder with the inputted variables
+func (b QueryBuilder) Variables(variables map[string]interface{}) QueryBuilder {
+	return QueryBuilder{
+		queries:   b.queries,
+		variables: mergeMap(b.variables, variables),
+	}
+}
+
+// RemoveQuery returns the new QueryBuilder with query items and related variables removed
+func (b QueryBuilder) Remove(query string, extra ...string) QueryBuilder {
+	var newQueries []queryBuilderItem
+	newVars := make(map[string]interface{})
+
+	for _, q := range b.queries {
+		if q.query == query || sliceStringContains(extra, q.query) {
+			continue
+		}
+		newQueries = append(newQueries, q)
+		if len(b.variables) > 0 {
+			for _, k := range q.requiredVars {
+				if v, ok := b.variables[k]; ok {
+					newVars[k] = v
+				}
+			}
+		}
+	}
+
+	return QueryBuilder{
+		queries:   newQueries,
+		variables: newVars,
+	}
+}
+
+// RemoveQuery returns the new QueryBuilder with query items removed
+// this method only remove query items only,
+// to remove both query and variables, use Remove instead
+func (b QueryBuilder) RemoveQuery(query string, extra ...string) QueryBuilder {
+	var newQueries []queryBuilderItem
+
+	for _, q := range b.queries {
+		if q.query != query && !sliceStringContains(extra, q.query) {
+			newQueries = append(newQueries, q)
+		}
+	}
+
+	return QueryBuilder{
+		queries:   newQueries,
+		variables: b.variables,
+	}
+}
+
+// RemoveQuery returns the new QueryBuilder with variable fields removed
+func (b QueryBuilder) RemoveVariable(key string, extra ...string) QueryBuilder {
+	newVars := make(map[string]interface{})
+	for k, v := range b.variables {
+		if k != key && !sliceStringContains(extra, k) {
+			newVars[k] = v
+		}
+	}
+
+	return QueryBuilder{
+		queries:   b.queries,
+		variables: newVars,
+	}
+}
+
+// Build query and variable interfaces
+func (b QueryBuilder) Build() ([]QueryBinding, map[string]interface{}, error) {
+	if len(b.queries) == 0 {
+		return nil, nil, errBuildQueryRequired
+	}
+
+	var requiredVars []string
+	for _, q := range b.queries {
+		requiredVars = append(requiredVars, q.requiredVars...)
+	}
+	variableLength := len(b.variables)
+	requiredVariableLength := len(requiredVars)
+	isMismatchedVariables := variableLength != requiredVariableLength
+	if !isMismatchedVariables && requiredVariableLength > 0 {
+		for _, varName := range requiredVars {
+			if _, ok := b.variables[varName]; !ok {
+				isMismatchedVariables = true
+				break
+			}
+		}
+	}
+	if isMismatchedVariables {
+		varNames := make([]string, 0, variableLength)
+		for k := range b.variables {
+			varNames = append(varNames, k)
+		}
+		return nil, nil, fmt.Errorf("mismatched variables; want: %+v; got: %+v", requiredVars, varNames)
+	}
+
+	query := make([]QueryBinding, 0, len(b.queries))
+	for _, q := range b.queries {
+		query = append(query, [2]interface{}{q.query, q.binding})
+	}
+	return query, b.variables, nil
+}
+
+func setMapValue(src map[string]interface{}, key string, value interface{}) map[string]interface{} {
+	if src == nil {
+		src = make(map[string]interface{})
+	}
+	src[key] = value
+	return src
+}
+
+func mergeMap(src map[string]interface{}, dest map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	for k, v := range src {
+		setMapValue(result, k, v)
+	}
+	for k, v := range dest {
+		setMapValue(result, k, v)
+	}
+	return result
+}
+
+func sliceStringContains(slice []string, val string) bool {
+	for _, s := range slice {
+		if s == val {
+			return true
+		}
+	}
+	return false
+}
+
+func findAllVariableNames(query string) []string {
+	var results []string
+	for _, names := range regexVariableName.FindAllStringSubmatch(query, -1) {
+		results = append(results, names[1])
+	}
+	return results
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,327 @@
+package graphql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/hasura/go-graphql-client"
+)
+
+func TestQueryBuilder(t *testing.T) {
+
+	queryStruct1 := func() interface{} {
+		m := struct {
+			ID   string
+			Name string
+		}{}
+		return &m
+	}
+
+	queryStruct2 := func() interface{} {
+		m := struct {
+			ID        string
+			Email     string
+			Addresses []struct {
+				Street string
+				City   string
+			}
+		}{}
+		return &m
+	}
+
+	queryStruct3 := func() interface{} {
+		m := struct {
+			ID     string
+			Email  string
+			Points []string
+		}{}
+		return &m
+	}
+
+	fixtures := []struct {
+		queries            map[string]interface{}
+		variables          map[string]interface{}
+		variableMismatched bool
+		err                error
+	}{
+		{
+			queries: map[string]interface{}{
+				"person":        queryStruct1(),
+				"personAddress": queryStruct2(),
+				"personPoint":   queryStruct3(),
+			},
+		},
+		{
+			queries: map[string]interface{}{
+				"person(id: $id)":               queryStruct1(),
+				"personAddress(id: $addressId)": queryStruct2(),
+				"personPoint(where: $where)":    queryStruct3(),
+			},
+			variables: map[string]interface{}{
+				"id":        nil,
+				"addressId": nil,
+				"where":     nil,
+			},
+		},
+		{
+			err: errors.New("no graphql query to be built"),
+		},
+		{
+			queries: map[string]interface{}{
+				"person(id: $id)":               queryStruct1(),
+				"personAddress(id: $addressId)": queryStruct2(),
+				"personPoint(where: $where)":    queryStruct3(),
+			},
+			variables: map[string]interface{}{
+				"id":        nil,
+				"addressId": nil,
+			},
+			variableMismatched: true,
+		},
+	}
+
+	for i, f := range fixtures {
+		builder := graphql.QueryBuilder{}
+		for q, b := range f.queries {
+			builder = builder.Query(q, b)
+		}
+		for k, v := range f.variables {
+			builder = builder.Variable(k, v)
+		}
+
+		queries, vars, err := builder.Build()
+		if f.variableMismatched && err != nil {
+			if !strings.Contains(err.Error(), "mismatched variables;") {
+				t.Errorf("[%d] got: %+v, want mismatched variables error", i, err)
+			}
+		} else if testEqualError(t, f.err, err, fmt.Sprintf("[%d]", i)) && f.err == nil && err == nil {
+			testEqualMap(t, f.variables, vars, fmt.Sprintf("[%d]", i))
+			queryFailed := len(queries) != len(f.queries)
+			if !queryFailed {
+				for _, q := range queries {
+					wantQuery, ok := f.queries[q[0].(string)]
+					if !ok || wantQuery != q[1] {
+						queryFailed = true
+						break
+					}
+				}
+			}
+			if queryFailed {
+				t.Errorf("[%d] queries mismatched. got: %+v, want: %+v", i, queries, f.queries)
+			}
+		}
+	}
+}
+
+func TestQueryBuilder_remove(t *testing.T) {
+
+	var queryStruct1 struct {
+		ID   string
+		Name string
+	}
+
+	var queryStruct2 struct {
+		ID        string
+		Email     string
+		Addresses []struct {
+			Street string
+			City   string
+		}
+	}
+
+	var queryStruct3 struct {
+		ID     string
+		Email  string
+		Points []string
+	}
+
+	fixture := struct {
+		queries   map[string]interface{}
+		variables map[string]interface{}
+	}{
+		queries: map[string]interface{}{
+			"person(id: $id)":               queryStruct1,
+			"personAddress(id: $addressId)": queryStruct2,
+			"personPoint(where: $where)":    queryStruct3,
+		},
+		variables: map[string]interface{}{
+			"id":        nil,
+			"addressId": nil,
+			"where":     nil,
+		},
+	}
+
+	builder := graphql.QueryBuilder{}
+	for q, b := range fixture.queries {
+		builder = builder.Query(q, b)
+	}
+	for k, v := range fixture.variables {
+		builder = builder.Variable(k, v)
+	}
+
+	builder = builder.RemoveQuery("person(id: $id)")
+	_, _, e1 := builder.Build()
+
+	if e1 == nil || !strings.Contains(e1.Error(), "mismatched variables;") {
+		t.Errorf("remove query failed, got: nil, want mismatched error")
+	}
+
+	builder = builder.RemoveVariable("id")
+	q2, v2, e2 := builder.Build()
+
+	if e2 != nil {
+		t.Errorf("remove query failed, got: %+v, want nil error", e2)
+	}
+
+	expected2 := [][2]interface{}{
+		{"personAddress(id: $addressId)", queryStruct2},
+		{"personPoint(where: $where)", queryStruct3},
+	}
+	if len(q2) != 2 {
+		t.Errorf("remove query failed, got: %+v, want %+v", q2, expected2)
+	}
+
+	testEqualMap(t, v2, map[string]interface{}{
+		"addressId": nil,
+		"where":     nil,
+	}, "remove query failed")
+
+	builder = builder.Remove("personPoint(where: $where)")
+	q3, v3, e3 := builder.Build()
+
+	if e3 != nil {
+		t.Errorf("remove query failed, got: %+v, want nil error", e3)
+	}
+
+	if len(q3) != 1 || q3[0][0] != "personAddress(id: $addressId)" {
+		t.Errorf("remove query failed, got: %+v, want %+v", q2, expected2)
+	}
+
+	testEqualMap(t, v3, map[string]interface{}{
+		"addressId": nil,
+	}, "remove query failed")
+
+}
+
+// Test query QueryBuilder output
+func TestQueryBuilder_Query(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+		body := mustRead(req.Body)
+		if got, want := body, `{"query":"query ($id:String!){user(id: $id){id,name}}","variables":{"id":"1"}}`+"\n"; got != want {
+			t.Errorf("got body: %v, want %v", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(w, `{"data": {"user": {"id": "1", "name": "Gopher"}}}`)
+	})
+	client := graphql.NewClient("/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
+
+	var user struct {
+		ID   string `graphql:"id"`
+		Name string `graphql:"name"`
+	}
+
+	bq, vars, err := graphql.NewQueryBuilder().Query("user(id: $id)", &user).Variable("id", "1").Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.Query(context.Background(), &bq, vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := user.Name, "Gopher"; got != want {
+		t.Errorf("got user.Name: %q, want: %q", got, want)
+	}
+	if got, want := user.ID, "1"; got != want {
+		t.Errorf("got user.ID: %q, want: %q", got, want)
+	}
+}
+
+// Test query QueryBuilder output with multiple queries
+func TestQueryBuilder_MultipleQueries(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, req *http.Request) {
+		body := mustRead(req.Body)
+		if got, want := body, `{"query":"{user{id,name}person{id,email,points}}"}`+"\n"; got != want {
+			t.Errorf("got body: %v, want %v", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		mustWrite(w, `{"data": {"user": {"id": "1", "name": "Gopher"},"person": [{"id": "2", "email": "gopher@domain", "points": ["1", "2"]}]}}`)
+	})
+	client := graphql.NewClient("/graphql", &http.Client{Transport: localRoundTripper{handler: mux}})
+
+	var user struct {
+		ID   string `graphql:"id"`
+		Name string `graphql:"name"`
+	}
+
+	q2 := make([]struct {
+		ID     string
+		Email  string
+		Points []string
+	}, 0)
+
+	bq, vars, err := graphql.NewQueryBuilder().Query("user", &user).Query("person", &q2).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = client.Query(context.Background(), &bq, vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := user.Name, "Gopher"; got != want {
+		t.Errorf("got user.Name: %q, want: %q", got, want)
+	}
+	if got, want := user.ID, "1"; got != want {
+		t.Errorf("got user.ID: %q, want: %q", got, want)
+	}
+	if got, want := q2[0].ID, "2"; got != want {
+		t.Errorf("got q2.ID: %q, want: %q", got, want)
+	}
+	if got, want := q2[0].Email, "gopher@domain"; got != want {
+		t.Errorf("got q2.Email: %q, want: %q", got, want)
+	}
+	if got, want := q2[0].Points, "[1 2]"; fmt.Sprint(got) != want {
+		t.Errorf("got q2.Points: %q, want: %q", got, want)
+	}
+}
+
+func testEqualError(t *testing.T, want error, got error, msg string) bool {
+	if (got == nil && want == nil) || (got != nil && want != nil && got.Error() == want.Error()) {
+		return true
+	}
+	if msg != "" {
+		msg = msg + " "
+	}
+
+	t.Errorf("%sgot: %+v, want: %+v", msg, got, want)
+	return false
+}
+
+func testEqualMap(t *testing.T, want map[string]interface{}, got map[string]interface{}, msg string) {
+	failed := len(want) != len(got)
+	if !failed && len(want) > 0 {
+		for key, val := range want {
+			v, ok := got[key]
+			if !ok || v != val {
+				failed = true
+				break
+			}
+		}
+	}
+
+	if failed {
+		if msg != "" {
+			msg = msg + " "
+		}
+		t.Errorf("%sgot: %+v, want: %+v", msg, got, want)
+	}
+}

--- a/pkg/jsonutil/graphql.go
+++ b/pkg/jsonutil/graphql.go
@@ -358,6 +358,9 @@ func (d *decoder) popAllVs() {
 func (d *decoder) popLeftArrayTemplates() {
 	for i := range d.vs {
 		v := d.vs[i].Top()
+		for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+			v = v.Elem()
+		}
 		if v.IsValid() {
 			v.Set(v.Slice(1, v.Len()))
 		}


### PR DESCRIPTION
Introduce the `QueryBuilder` structure that wraps the naive `[][2]interface{}` type.  It helps construct multiple queries to a request that needs to be conditionally added.


You might need to dynamically multiple queries or mutations in a single request. It isn't convenient with static structures.
`QueryBuilder` helps us construct many queries flexibly.

For example, to make the following GraphQL mutation:

```GraphQL
query($userId: String!, $disabled: Boolean!, $limit: Int!) {
	userByPk(userId: $userId) { id name }
	groups(disabled: $disabled) { id user_permissions }
	topUsers: users(limit: $limit) { id name }
}

# variables {
# 	"userId": "1",
# 	"disabled": false,
# 	"limit": 5
# }
```

You can define:

```Go
type User struct {
	ID string
	Name string
}

var groups []struct {
	ID string
	Permissions []string `graphql:"user_permissions"`
}

var userByPk User
var topUsers []User

query, variables, err := graphql.NewQueryBuilder().
	Query("userByPk(userId: $userId)", &userByPk).
	Query("groups(disabled: $disabled)", &groups).
	Query("topUsers: users(limit: $limit)", &topUsers).
	Variables(map[string]interface{}{
		"userId": 1,
		"disabled": false,
		"limit": 5,
	})
	Build()

if err != nil {
	return err
}

err = client.Query(context.Background(), query, variables)
if err != nil {
	return err
}
```