### PR TITLE
fix bug:  Transport WS  On Error Message not invoke subscription handler 

### DIFF
--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -114,6 +114,16 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 	switch message.Type {
 	case GQLError:
 		ctx.Log(message, "server", GQLError)
+		var errs Errors
+		jsonErr := json.Unmarshal(message.Payload, &errs)
+		if jsonErr != nil {
+			subscription.handler(nil, fmt.Errorf("%s", string(message.Payload)))
+			return nil
+		}
+		if len(errs) > 0 {
+			subscription.handler(nil, errs)
+			return nil
+		}
 	case GQLData:
 		ctx.Log(message, "server", GQLData)
 		var out struct {


### PR DESCRIPTION
In the OnMessage function of the protocol graphqlWS and subscriptionsTransportWS, errors with message type error are inconsistent

Expected consistent error handling