### PR TITLE
update gh actions and go versions, update deprecated ioutil

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: "1.16.4"
-      - uses: actions/cache@v2
+          go-version: "1.20"
+      - uses: actions/cache@v3
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install dependencies
-        run: go install -t -v ./...
+        run: go install ./...
       - name: Format
         run: diff -u <(echo -n) <(gofmt -d -s .)
       - name: Vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install dependencies
-        run: go get -t -v ./...
+        run: go install -t -v ./...
       - name: Format
         run: diff -u <(echo -n) <(gofmt -d -s .)
       - name: Vet
@@ -42,7 +42,7 @@ jobs:
         run: go test -v -race -timeout 3m -coverprofile=coverage.out ./...
       - name: Go coverage format
         run: |
-          go get github.com/boumenot/gocover-cobertura
+          go install github.com/boumenot/gocover-cobertura
           gocover-cobertura < coverage.out > coverage.xml
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Install dependencies
-        run: go install ./...
+        run: |
+          go get -t -v ./...
+          go install ./...
       - name: Format
         run: diff -u <(echo -n) <(gofmt -d -s .)
       - name: Vet
@@ -42,6 +44,7 @@ jobs:
         run: go test -v -race -timeout 3m -coverprofile=coverage.out ./...
       - name: Go coverage format
         run: |
+          go get github.com/boumenot/gocover-cobertura
           go install github.com/boumenot/gocover-cobertura
           gocover-cobertura < coverage.out > coverage.xml
       - name: Code Coverage Summary Report

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,19 @@
 module github.com/hasura/go-graphql-client
 
-go 1.16
+go 1.20
 
 require (
 	github.com/google/uuid v1.3.0
 	github.com/graph-gophers/graphql-go v1.5.0
 	github.com/graph-gophers/graphql-transport-ws v0.0.2
+	nhooyr.io/websocket v1.8.7
+)
+
+require (
+	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/klauspost/compress v1.16.7 // indirect
 	golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
-	nhooyr.io/websocket v1.8.7
 )
 
 replace github.com/gin-gonic/gin v1.6.3 => github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
+github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v1.5.0 h1:fDqblo50TEpD0LY7RXk/LFVYEVqo3+tXMNMPSVXA1yc=
 github.com/graph-gophers/graphql-go v1.5.0/go.mod h1:YtmJZDLbF1YYNrlNAuiO5zAStUWc3XZT07iGsVqe1Os=
 github.com/graph-gophers/graphql-transport-ws v0.0.2 h1:DbmSkbIGzj8SvHei6n8Mh9eLQin8PtA8xY9eCzjRpvo=
@@ -40,6 +42,8 @@ github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGn
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/klauspost/compress v1.10.3 h1:OP96hzwJVBIHYU52pVTI6CczrxPvrGfgqF9N5eTO0Q8=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=

--- a/graphql.go
+++ b/graphql.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -173,7 +172,7 @@ func (c *Client) request(ctx context.Context, query string, variables map[string
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		err := newError(ErrRequestError, fmt.Errorf("%v; body: %q", resp.Status, body))
 
 		if c.debug {
@@ -190,7 +189,7 @@ func (c *Client) request(ctx context.Context, query string, variables map[string
 	// copy the response reader for debugging
 	var respReader *bytes.Reader
 	if c.debug {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, nil, nil, Errors{newError(ErrJsonDecode, err)}
 		}
@@ -356,7 +355,7 @@ func newError(code string, err error) Error {
 
 func (e Error) withRequest(req *http.Request, bodyReader io.Reader) Error {
 	internal := e.getInternalExtension()
-	bodyBytes, err := ioutil.ReadAll(bodyReader)
+	bodyBytes, err := io.ReadAll(bodyReader)
 	if err != nil {
 		internal["error"] = err
 	} else {
@@ -375,7 +374,7 @@ func (e Error) withRequest(req *http.Request, bodyReader io.Reader) Error {
 
 func (e Error) withResponse(res *http.Response, bodyReader io.Reader) Error {
 	internal := e.getInternalExtension()
-	bodyBytes, err := ioutil.ReadAll(bodyReader)
+	bodyBytes, err := io.ReadAll(bodyReader)
 	if err != nil {
 		internal["error"] = err
 	} else {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -427,7 +426,7 @@ func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func mustRead(r io.Reader) string {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Version Updates
- Update Github Actions since these actions are built on [deprecated node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) tagged actions.
- Update Go module version to 1.20. The EOL of current Go version 1.16 was on [15 Mar 2022](https://endoflife.date/go).
- Update `ioutil.ReadAll` to `io.ReadAll` 

All go.mod updates were a result of setting `go 1.20` in `go.mod` then running `go get -u ./...` followed by `go mod tidy`.
