### PR TITLE
feat: added optional WithKeepAlive and WithRetryDelay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hasura/go-graphql-client
+module github.com/applyinnovations/go-graphql-client
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/applyinnovations/go-graphql-client
+module github.com/hasura/go-graphql-client
 
 go 1.20
 


### PR DESCRIPTION
Some servers requires the client to send ping to prevent connection from being broken due to idling. We have added `WithKeepAlive` which accepts `time.Duration` that will be use as interval for doing a continuous ping to the server. This is also implemented in npm package [graphql-ws](https://the-guild.dev/graphql/ws/docs/modules/use_ws#parameters). 

`WithRetryDelay` makes retry delay customizable. If not set it will use the default (currently hard coded 1 second).