### PR TITLE
feat: add sync mode for subscription events

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,9 @@ client.
 	WithExitWhenNoSubscription(false).
 	// WithRetryStatusCodes allow retry the subscription connection when receiving one of these codes
 	// the input parameter can be number string or range, e.g 4000-5000
-	WithRetryStatusCodes("4000", "4000-4050")
+	WithRetryStatusCodes("4000", "4000-4050").
+	// WithSyncMode subscription messages are executed in sequence (without goroutine)
+	WithSyncMode(true)
 ```
 
 #### Subscription Protocols

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -13,7 +13,8 @@ import (
 	"nhooyr.io/websocket"
 )
 
-func TestSubscription_LifeCycleEvents(t *testing.T) {
+func testSubscription_LifeCycleEvents(t *testing.T, syncMode bool) {
+
 	server := subscription_setupServer(8082)
 	client, subscriptionClient := subscription_setupClients(8082)
 	msg := randomID()
@@ -84,6 +85,7 @@ func TestSubscription_LifeCycleEvents(t *testing.T) {
 	subscriptionClient = subscriptionClient.
 		WithExitWhenNoSubscription(false).
 		WithTimeout(3 * time.Second).
+		WithSyncMode(syncMode).
 		OnConnected(func() {
 			lock.Lock()
 			defer lock.Unlock()
@@ -198,6 +200,14 @@ func TestSubscription_LifeCycleEvents(t *testing.T) {
 	if !wasDisconnected {
 		t.Fatalf("expected OnDisconnected event, got none")
 	}
+}
+
+func TestSubscription_LifeCycleEvents(t *testing.T) {
+	testSubscription_LifeCycleEvents(t, false)
+}
+
+func TestSubscription_WithSyncMode(t *testing.T) {
+	testSubscription_LifeCycleEvents(t, true)
 }
 
 func TestSubscription_WithRetryStatusCodes(t *testing.T) {


### PR DESCRIPTION
close https://github.com/hasura/go-graphql-client/issues/113

Add a new `syncMode` option to allow subscriptions to execute messages in sequence (without goroutine)
```go
client.WithSyncMode(true)
```