### PR TITLE
Add Unwrap() implementations for Error types

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -327,13 +327,13 @@ type Errors []Error
 
 type Error struct {
 	Message    string                 `json:"message"`
-	Err        error                  `json:"-"`
 	Extensions map[string]interface{} `json:"extensions"`
 	Locations  []struct {
 		Line   int `json:"line"`
 		Column int `json:"column"`
 	} `json:"locations"`
 	Path []interface{} `json:"path"`
+	err  error
 }
 
 // Error implements error interface.
@@ -343,7 +343,7 @@ func (e Error) Error() string {
 
 // Unwrap implement the unwrap interface.
 func (e Error) Unwrap() error {
-	return e.Err
+	return e.err
 }
 
 // Error implements error interface.
@@ -359,7 +359,7 @@ func (e Errors) Error() string {
 func (e Errors) Unwrap() []error {
 	var errs []error
 	for _, err := range e {
-		errs = append(errs, err.Err)
+		errs = append(errs, err.err)
 	}
 	return errs
 }
@@ -379,10 +379,10 @@ func (e Error) getInternalExtension() map[string]interface{} {
 func newError(code string, err error) Error {
 	return Error{
 		Message: err.Error(),
-		Err:     err,
 		Extensions: map[string]interface{}{
 			"code": code,
 		},
+		err: err,
 	}
 }
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -253,6 +253,63 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 	}
 }
 
+func TestClient_Query_requestError(t *testing.T) {
+	want := errors.New("bad error")
+	client := graphql.NewClient("/graphql", &http.Client{Transport: errorRoundTripper{err: want}})
+
+	var q struct {
+		User struct {
+			Name string
+		}
+	}
+	err := client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if got, want := err.Error(), `Message: Post "/graphql": bad error, Locations: [], Extensions: map[code:request_error], Path: []`; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	if q.User.Name != "" {
+		t.Errorf("got non-empty q.User.Name: %v", q.User.Name)
+	}
+	if got := err; !errors.Is(got, want) {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+
+	gqlErr := err.(graphql.Errors)
+	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	if _, ok := gqlErr[0].Extensions["internal"]; ok {
+		t.Errorf("expected empty internal error")
+	}
+	if got := gqlErr[0].Err; !errors.Is(err, want) {
+		t.Errorf("got error: %v, want %v", got, want)
+	}
+
+	// test internal error data
+	client = client.WithDebug(true)
+	err = client.Query(context.Background(), &q, nil)
+	if err == nil {
+		t.Fatal("got error: nil, want: non-nil")
+	}
+	if !errors.As(err, &graphql.Errors{}) {
+		t.Errorf("the error type should be graphql.Errors")
+	}
+	gqlErr = err.(graphql.Errors)
+	if got, want := gqlErr[0].Message, `Post "/graphql": bad error`; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+	interErr := gqlErr[0].Extensions["internal"].(map[string]interface{})
+
+	if got, want := interErr["request"].(map[string]interface{})["body"], "{\"query\":\"{user{name}}\"}\n"; got != want {
+		t.Errorf("got error: %v, want: %v", got, want)
+	}
+}
+
 // Test that an empty (but non-nil) variables map is
 // handled no differently than a nil variables map.
 func TestClient_Query_emptyVariables(t *testing.T) {
@@ -423,6 +480,16 @@ func (l localRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 	w := httptest.NewRecorder()
 	l.handler.ServeHTTP(w, req)
 	return w.Result(), nil
+}
+
+// errorRoundTripper is an http.RoundTripper that always returns the supplied
+// error.
+type errorRoundTripper struct {
+	err error
+}
+
+func (e errorRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, e.err
 }
 
 func mustRead(r io.Reader) string {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -283,7 +283,7 @@ func TestClient_Query_requestError(t *testing.T) {
 	if _, ok := gqlErr[0].Extensions["internal"]; ok {
 		t.Errorf("expected empty internal error")
 	}
-	if got := gqlErr[0].Err; !errors.Is(err, want) {
+	if got := gqlErr[0]; !errors.Is(err, want) {
 		t.Errorf("got error: %v, want %v", got, want)
 	}
 


### PR DESCRIPTION
Fixes #127.

Adds `Unwrap()` to `Error` and `Errors`.