### PR TITLE
returns NetworkError when the request response returns a non-200 http status code

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -178,9 +178,10 @@ func (c *Client) request(ctx context.Context, query string, variables map[string
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
 		err := newError(ErrRequestError, NetworkError{
-			message:    "non-200 OK status code",
 			statusCode: resp.StatusCode,
+			body:       string(b),
 		})
 
 		if c.debug {
@@ -389,12 +390,16 @@ func newError(code string, err error) Error {
 }
 
 type NetworkError struct {
-	message    string
+	body       string
 	statusCode int
 }
 
 func (e NetworkError) Error() string {
-	return fmt.Sprintf("%d %s: %s", e.statusCode, http.StatusText(e.statusCode), e.message)
+	return fmt.Sprintf("%d %s", e.statusCode, http.StatusText(e.statusCode))
+}
+
+func (e NetworkError) Body() string {
+	return e.body
 }
 
 func (e NetworkError) StatusCode() int {

--- a/graphql.go
+++ b/graphql.go
@@ -178,9 +178,8 @@ func (c *Client) request(ctx context.Context, query string, variables map[string
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		err := newError(ErrRequestError, ErrResponseStatusNotOK{
-			body:       resp.Body,
-			status:     resp.Status,
+		err := newError(ErrRequestError, NetworkError{
+			message:    "non-200 OK status code",
 			statusCode: resp.StatusCode,
 		})
 
@@ -389,25 +388,16 @@ func newError(code string, err error) Error {
 	}
 }
 
-type ErrResponseStatusNotOK struct {
-	body       io.ReadCloser
-	status     string
+type NetworkError struct {
+	message    string
 	statusCode int
 }
 
-func (e ErrResponseStatusNotOK) Error() string {
-	return fmt.Sprintf("non-200 OK status code: %s", e.status)
+func (e NetworkError) Error() string {
+	return fmt.Sprintf("%d %s: %s", e.statusCode, http.StatusText(e.statusCode), e.message)
 }
 
-func (e ErrResponseStatusNotOK) Body() io.ReadCloser {
-	return e.body
-}
-
-func (e ErrResponseStatusNotOK) Status() string {
-	return e.status
-}
-
-func (e ErrResponseStatusNotOK) StatusCode() int {
+func (e NetworkError) StatusCode() int {
 	return e.statusCode
 }
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -240,7 +240,7 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 		t.Errorf("the error type should be graphql.Errors")
 	}
 	gqlErr = err.(graphql.Errors)
-	if got, want := gqlErr[0].Message, `500 Internal Server Error"`; got != want {
+	if got, want := gqlErr[0].Message, `500 Internal Server Error`; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -215,7 +215,7 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 	if err == nil {
 		t.Fatal("got error: nil, want: non-nil")
 	}
-	if got, want := err.Error(), `Message: 500 Internal Server Error; body: "important message\n", Locations: [], Extensions: map[code:request_error], Path: []`; got != want {
+	if got, want := err.Error(), `Message: 500 Internal Server Error, Locations: [], Extensions: map[code:request_error], Path: []`; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if q.User.Name != "" {
@@ -240,7 +240,7 @@ func TestClient_Query_errorStatusCode(t *testing.T) {
 		t.Errorf("the error type should be graphql.Errors")
 	}
 	gqlErr = err.(graphql.Errors)
-	if got, want := gqlErr[0].Message, `500 Internal Server Error; body: "important message\n"`; got != want {
+	if got, want := gqlErr[0].Message, `500 Internal Server Error"`; got != want {
 		t.Errorf("got error: %v, want: %v", got, want)
 	}
 	if got, want := gqlErr[0].Extensions["code"], graphql.ErrRequestError; got != want {


### PR DESCRIPTION
This PR adds a new error type: ErrResponseStatusNotOK

This error contains the status code and response body which were previously returned as the error message.

This change has two benefits:
* Allows systems that depend on this package to be able to check for error response codes by using go's inbuilt errors package and matching on the error code, rather than string matching on the error message.
* ~Returns the body of the request as an `io.Reader` to reduce unnecessary data being passed around.~

```go
// Before 
err := client.Query(ctx, query, variables)
if err != nil {
	serviceErrRegex := regexp.MustCompile(`^non-200 OK status code: 5\d\d.+`)
	if serviceErrRegex.MatchString(err.Error()) {
		// handle 5xx status response
	}
}
```
```go
// After
err := client.Query(ctx, query, variables)
statusErr := graphql.ErrResponseStatusNotOK{}
if errors.As(err, &statusErr) && statusErr.StatusCode() >= 500 && statusErr.StatusCode() < 600 {
	// handle 5xx status response
}
```