### PR TITLE
migrate nhooyr.io/websocket to github.com/coder/websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Preface:** This is a fork of `https://github.com/shurcooL/graphql` with extended features (subscription client, named operation)
 
-The subscription client follows Apollo client specification https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md, using WebSocket protocol with https://github.com/nhooyr/websocket, a minimal and idiomatic WebSocket library for Go.
+The subscription client follows Apollo client specification https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md, using WebSocket protocol with https://github.com/coder/websocket, a minimal and idiomatic WebSocket library for Go.
 
 Package `graphql` provides a GraphQL client implementation.
 
@@ -672,7 +672,7 @@ client.WithWebSocketOptions(WebsocketOptions{
 
 #### Custom WebSocket client
 
-By default, the subscription client uses [nhooyr WebSocket client](https://github.com/nhooyr/websocket). If you need to customize the client or prefer using [Gorilla WebSocket](https://github.com/gorilla/websocket), let's follow the WebSocket interface and replace the constructor with `WithWebSocket` method:
+By default, the subscription client uses [coder WebSocket client](https://github.com/coder/websocket). If you need to customize the client or prefer using [Gorilla WebSocket](https://github.com/gorilla/websocket), let's follow the WebSocket interface and replace the constructor with `WithWebSocket` method:
 
 ```go
 // WebsocketHandler abstracts WebSocket connection functions
@@ -706,7 +706,7 @@ func newWebsocketConn(sc *SubscriptionClient) (WebsocketConn, error) {
 		return nil, err
 	}
 
-	// The default WebsocketHandler implementation using nhooyr's
+	// The default WebsocketHandler implementation using coder's
 	return &WebsocketHandler{
 		ctx:     sc.GetContext(),
 		Conn:    c,
@@ -992,7 +992,7 @@ Because the GraphQL query string is generated in runtime using reflection, it is
 
 - https://github.com/shurcooL/graphql
 - https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
-- https://github.com/nhooyr/websocket
+- https://github.com/coder/websocket
 
 ## License
 

--- a/example/subscription/go.mod
+++ b/example/subscription/go.mod
@@ -9,9 +9,9 @@ require (
 )
 
 require (
+	github.com/coder/websocket v1.8.12 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
-	nhooyr.io/websocket v1.8.10 // indirect
 )
 
 replace github.com/hasura/go-graphql-client => ../../

--- a/example/subscription/go.sum
+++ b/example/subscription/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -26,5 +28,3 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-nhooyr.io/websocket v1.8.10 h1:mv4p+MnGrLDcPlBoWsvPP7XCzTYMXP9F9eIGoKbgx7Q=
-nhooyr.io/websocket v1.8.10/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/hasura/go-graphql-client
 go 1.20
 
 require (
+	github.com/coder/websocket v1.8.12
 	github.com/google/uuid v1.6.0
-	nhooyr.io/websocket v1.8.11
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-nhooyr.io/websocket v1.8.11 h1:f/qXNc2/3DpoSZkHt1DQu6rj4zGC8JmkkLkWss0MgN0=
-nhooyr.io/websocket v1.8.11/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/subscription.go
+++ b/subscription.go
@@ -14,9 +14,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
+	"github.com/google/uuid"
 )
 
 // SubscriptionProtocolType represents the protocol specification enum of the subscription

--- a/subscription.go
+++ b/subscription.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"nhooyr.io/websocket"
-	"nhooyr.io/websocket/wsjson"
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 )
 
 // SubscriptionProtocolType represents the protocol specification enum of the subscription
@@ -419,7 +419,7 @@ func (sc *SubscriptionClient) GetSubscription(id string) *Subscription {
 }
 
 // WithWebSocket replaces customized websocket client constructor
-// In default, subscription client uses https://github.com/nhooyr/websocket
+// In default, subscription client uses https://github.com/coder/websocket
 func (sc *SubscriptionClient) WithWebSocket(fn func(sc *SubscriptionClient) (WebsocketConn, error)) *SubscriptionClient {
 	sc.createConn = fn
 	return sc
@@ -1014,7 +1014,7 @@ func parseInt32Ranges(codes []string) ([][]int32, error) {
 	return statusCodes, nil
 }
 
-// default websocket handler implementation using https://github.com/nhooyr/websocket
+// default websocket handler implementation using https://github.com/coder/websocket
 type WebsocketHandler struct {
 	ctx     context.Context
 	timeout time.Duration
@@ -1069,7 +1069,7 @@ func (wh *WebsocketHandler) GetCloseStatus(err error) int32 {
 }
 
 // the default constructor function to create a websocket client
-// which uses https://github.com/nhooyr/websocket library
+// which uses https://github.com/coder/websocket library
 func newWebsocketConn(sc *SubscriptionClient) (WebsocketConn, error) {
 
 	options := &websocket.DialOptions{

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 )
 
 const (

--- a/subscriptions_transport_ws_test.go
+++ b/subscriptions_transport_ws_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 )
 
 func TestSubscription_WithRetryStatusCodes(t *testing.T) {


### PR DESCRIPTION
`nhooyr.io/websocket` is deprecated and stopped working (my CI builds failed)

the new repo is `github.com/coder/websocket`

related info:
https://pkg.go.dev/nhooyr.io/websocket
https://coder.com/blog/websocket

also we need a version bump to fix the examples directory.