### PR TITLE
fix: subscription goroutine leaks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/*.yml"
+      - "example/hasura/docker-compose.yaml"
+
+jobs:
+  lint:
+    name: Run Go lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.20"
+      - name: Install dependencies
+        run: |
+          go get -t -v ./...
+          go install ./...
+      - name: Format
+        run: diff -u <(echo -n) <(gofmt -d -s .)
+      - name: Vet
+        run: go vet ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          only-new-issues: true
+          skip-cache: true
+          args: --timeout=120s

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,12 @@ name: Unit tests
 on:
   pull_request:
   push:
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/*.yml"
-      - "example/hasura/docker-compose.yaml"
+    branches:
+      - master
 
 jobs:
   test-go:
-    name: Run Go lint and unit tests
+    name: Run unit and integration tests
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -30,21 +26,10 @@ jobs:
         run: |
           go get -t -v ./...
           go install ./...
-      - name: Format
-        run: diff -u <(echo -n) <(gofmt -d -s .)
-      - name: Vet
-        run: go vet ./...
       - name: Setup integration test infrastructure
         run: |
           cd ./example/hasura
           docker compose up -d
-      - name: Lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          only-new-issues: true
-          skip-cache: true
-          args: --timeout=120s
       - name: Run Go unit tests for example/subscription
         run: |
           cd example/subscription

--- a/example/hasura/docker-compose.yaml
+++ b/example/hasura/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     image: postgres:15
@@ -24,6 +22,7 @@ services:
       ## enable the console served by server
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup,http-log,query-log,webhook-log,websocket-log
+      HASURA_GRAPHQL_LOG_LEVEL: debug
       ## enable debugging mode. It is recommended to disable this in production
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ADMIN_SECRET: hasura

--- a/example/hasura/docker-compose.yaml
+++ b/example/hasura/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgrespassword
 
   hasura:
-    image: hasura/graphql-engine:v2.45.1.cli-migrations-v3
+    image: hasura/graphql-engine:v2.16.1.cli-migrations-v3
     depends_on:
       - "postgres"
     ports:

--- a/example/hasura/docker-compose.yaml
+++ b/example/hasura/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgrespassword
 
   hasura:
-    image: hasura/graphql-engine:v2.16.1.cli-migrations-v3
+    image: hasura/graphql-engine:v2.45.1.cli-migrations-v3
     depends_on:
       - "postgres"
     ports:

--- a/example/subscription/subscription_test.go
+++ b/example/subscription/subscription_test.go
@@ -556,3 +556,69 @@ func TestSubscription_LifeCycleEvents(t *testing.T) {
 func TestSubscription_WithSyncMode(t *testing.T) {
 	testSubscription_LifeCycleEvents(t, true)
 }
+
+func TestTransportWS_ConnectionIdleTimeout(t *testing.T) {
+	server := subscription_setupServer(8081)
+	_, subscriptionClient := subscription_setupClients(8081)
+	msg := randomID()
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			log.Println(err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() {
+		_ = server.Shutdown(ctx)
+	}()
+	defer cancel()
+
+	subscriptionClient.
+		WithWebsocketConnectionIdleTimeout(2 * time.Second).
+		OnError(func(sc *gql.SubscriptionClient, err error) error {
+			return err
+		})
+
+	/*
+		subscription {
+			helloSaid {
+				id
+				msg
+			}
+		}
+	*/
+	var sub struct {
+		HelloSaid struct {
+			ID      gql.String
+			Message gql.String `graphql:"msg" json:"msg"`
+		} `graphql:"helloSaid" json:"helloSaid"`
+	}
+
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if sub.HelloSaid.Message != gql.String(msg) {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.HelloSaid.Message, msg)
+		}
+
+		return errors.New("exit")
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	if err := subscriptionClient.Run(); err == nil || !errors.Is(err, gql.ErrWebsocketConnectionIdleTimeout) {
+		t.Errorf("got error: %v, want: %s", err, gql.ErrWebsocketConnectionIdleTimeout)
+	}
+}

--- a/example/subscription/subscription_test.go
+++ b/example/subscription/subscription_test.go
@@ -530,8 +530,8 @@ func testSubscription_LifeCycleEvents(t *testing.T, syncMode bool) {
 		t.Fatalf("failed to listen OnSubscriptionComplete event. got %+v, want: %+v", len(subscriptionResults), len(fixtures))
 	}
 	for i, s := range subscriptionResults {
-		if s.GetID() != fixtures[i].ExpectedID {
-			t.Fatalf("%d: subscription id not matched, got: %s, want: %s", i, s.GetPayload().Query, fixtures[i].ExpectedPayload.Query)
+		if s.GetKey() != fixtures[i].ExpectedID {
+			t.Fatalf("%d: subscription id not matched, got: %s, want: %s", i, s.GetKey(), fixtures[i].ExpectedID)
 		}
 		if s.GetPayload().Query != fixtures[i].ExpectedPayload.Query {
 			t.Fatalf("%d: query output not matched, got: %s, want: %s", i, s.GetPayload().Query, fixtures[i].ExpectedPayload.Query)

--- a/subscription.go
+++ b/subscription.go
@@ -1238,6 +1238,7 @@ func (sc *SubscriptionClient) initNewSession(ctx context.Context) (*Subscription
 	currentSession := sc.getCurrentSession()
 	if currentSession != nil {
 		_ = currentSession.Close()
+		time.Sleep(sc.retryDelay)
 	}
 
 	subContext := &SubscriptionContext{

--- a/subscription.go
+++ b/subscription.go
@@ -224,13 +224,6 @@ func (sc *SubscriptionContext) getConnectionInitAt() time.Time {
 	return sc.connectionInitAt
 }
 
-func (sc *SubscriptionContext) setConnectionInitAt(t time.Time) {
-	sc.mutex.Lock()
-	defer sc.mutex.Unlock()
-
-	sc.connectionInitAt = t
-}
-
 func (sc *SubscriptionContext) setLastReceivedMessageAt(t time.Time) {
 	sc.mutex.Lock()
 	defer sc.mutex.Unlock()

--- a/subscription.go
+++ b/subscription.go
@@ -80,8 +80,7 @@ var (
 	// ErrSubscriptionNotExists an error denoting that subscription does not exist
 	ErrSubscriptionNotExists = errors.New("subscription does not exist")
 
-	errSubscriptionClientIsAlreadyRunning = errors.New("the subscription client is already running")
-	errRetry                              = errors.New("retry subscription client")
+	errRetry = errors.New("retry subscription client")
 )
 
 // OperationMessage represents a subscription operation message
@@ -1106,7 +1105,7 @@ func (sc *SubscriptionClient) RunWithContext(ctx context.Context) error {
 			}
 
 			if sc.connectionInitialisationTimeout > 0 && !session.GetAcknowledge() &&
-				time.Now().Sub(session.connectionInitAt) > sc.connectionInitialisationTimeout {
+				time.Since(session.connectionInitAt) > sc.connectionInitialisationTimeout {
 				sc.errorChan <- &websocket.CloseError{
 					Code:   StatusConnectionInitialisationTimeout,
 					Reason: "Connection initialisation timeout",

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -82,7 +82,6 @@ func (gws *graphqlWS) Unsubscribe(ctx *SubscriptionContext, sub Subscription) er
 
 // OnMessage listens ongoing messages from server
 func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) error {
-
 	switch message.Type {
 	case GQLError:
 		ctx.Log(message, "server", message.Type)

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -125,23 +125,18 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 	case GQLComplete:
 		ctx.Log(message, "server", message.Type)
 		sub := ctx.GetSubscription(message.ID)
-		if ctx.OnSubscriptionComplete != nil {
-			if sub == nil {
-				ctx.OnSubscriptionComplete(Subscription{
-					id: message.ID,
-				})
-			} else {
-				ctx.OnSubscriptionComplete(*sub)
-			}
-		}
-		if sub != nil {
+		if sub == nil {
+			ctx.OnSubscriptionComplete(Subscription{
+				id: message.ID,
+			})
+		} else {
+			ctx.OnSubscriptionComplete(*sub)
 			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLPing:
 		ctx.Log(message, "server", GQLPing)
-		if ctx.OnConnectionAlive != nil {
-			ctx.OnConnectionAlive()
-		}
+		ctx.OnConnectionAlive()
+
 		// send pong response message back to the server
 		msg := OperationMessage{
 			Type:    GQLPong,
@@ -162,9 +157,8 @@ func (gws *graphqlWS) OnMessage(ctx *SubscriptionContext, subscription Subscript
 				return nil
 			}
 		}
-		if ctx.OnConnected != nil {
-			ctx.OnConnected()
-		}
+
+		ctx.OnConnected()
 	default:
 		ctx.Log(message, "server", GQLUnknown)
 	}

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -156,7 +156,7 @@ func TestGraphqlWS_Subscription(t *testing.T) {
 	defer subscriptionClient.Close()
 
 	// wait until the subscription client connects to the server
-	if err := waitHasuraService(60); err != nil {
+	if err := waitHasuraService(120); err != nil {
 		t.Fatalf("failed to start hasura service: %s", err)
 	}
 

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -376,3 +376,193 @@ func TestGraphQLWS_OnError(t *testing.T) {
 
 	<-stop
 }
+
+func TestSubscription_WithRetryStatusCodes(t *testing.T) {
+	stop := make(chan bool)
+	msg := randomID()
+	disconnectedCount := 0
+	subscriptionClient := NewSubscriptionClient(fmt.Sprintf("%s/v1/graphql", hasuraTestHost)).
+		WithProtocol(GraphQLWS).
+		WithRetryStatusCodes("4400").
+		WithConnectionParams(map[string]interface{}{
+			"headers": map[string]string{
+				"x-hasura-admin-secret": "test",
+			},
+		}).WithLog(log.Println).
+		OnDisconnected(func() {
+			disconnectedCount++
+			if disconnectedCount > 5 {
+				stop <- true
+			}
+		}).
+		OnError(func(sc *SubscriptionClient, err error) error {
+			t.Fatal("should not receive error")
+			return err
+		})
+
+	/*
+		subscription {
+			user {
+				id
+				name
+			}
+		}
+	*/
+	var sub struct {
+		Users []struct {
+			ID   int    `graphql:"id"`
+			Name string `graphql:"name"`
+		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+	}
+
+	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		log.Println("result", string(data))
+		e = json.Unmarshal(data, &sub)
+		if e != nil {
+			t.Fatalf("got error: %v, want: nil", e)
+			return nil
+		}
+
+		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
+			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	go func() {
+		if err := subscriptionClient.Run(); err != nil && websocket.CloseStatus(err) == 4400 {
+			t.Errorf("should not get error 4400, got error: %v, want: nil", err)
+		}
+	}()
+
+	defer subscriptionClient.Close()
+
+	// wait until the subscription client connects to the server
+	if err := waitHasuraService(60); err != nil {
+		t.Fatalf("failed to start hasura service: %s", err)
+	}
+
+	<-stop
+}
+
+func TestSubscription_closeThenRun(t *testing.T) {
+	_, subscriptionClient := hasura_setupClients(GraphQLWS)
+
+	fixtures := []struct {
+		Query        interface{}
+		Variables    map[string]interface{}
+		Subscription *Subscription
+	}{
+		{
+			Query: func() interface{} {
+				var t struct {
+					Users []struct {
+						ID   int    `graphql:"id"`
+						Name string `graphql:"name"`
+					} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+				}
+
+				return t
+			}(),
+			Variables: nil,
+			Subscription: &Subscription{
+				payload: GraphQLRequestPayload{
+					Query: "subscription{helloSaid{id,msg}}",
+				},
+			},
+		},
+		{
+			Query: func() interface{} {
+				var t struct {
+					Users []struct {
+						ID int `graphql:"id"`
+					} `graphql:"user(order_by: { id: desc }, limit: 5)"`
+				}
+
+				return t
+			}(),
+			Variables: nil,
+			Subscription: &Subscription{
+				payload: GraphQLRequestPayload{
+					Query: "subscription{helloSaid{msg}}",
+				},
+			},
+		},
+	}
+
+	subscriptionClient = subscriptionClient.
+		WithExitWhenNoSubscription(false).
+		WithTimeout(3 * time.Second).
+		OnError(func(sc *SubscriptionClient, err error) error {
+			t.Fatalf("got error: %v, want: nil", err)
+			return err
+		})
+
+	bulkSubscribe := func() {
+
+		for _, f := range fixtures {
+			id, err := subscriptionClient.Subscribe(f.Query, f.Variables, func(data []byte, e error) error {
+				if e != nil {
+					t.Fatalf("got error: %v, want: nil", e)
+					return nil
+				}
+				return nil
+			})
+
+			if err != nil {
+				t.Fatalf("got error: %v, want: nil", err)
+			}
+			log.Printf("subscribed: %s", id)
+		}
+	}
+
+	bulkSubscribe()
+
+	go func() {
+		if err := subscriptionClient.Run(); err != nil {
+			t.Errorf("got error: %v, want: nil", err)
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	if err := subscriptionClient.Close(); err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+
+	bulkSubscribe()
+
+	go func() {
+		length := len(subscriptionClient.GetSubscriptions())
+		if length != 2 {
+			t.Errorf("unexpected subscription client. got: %d, want: 2", length)
+			return
+		}
+
+		waitingLen := subscriptionClient.getCurrentSession().GetSubscriptionsLength([]SubscriptionStatus{SubscriptionWaiting})
+		if waitingLen != 2 {
+			t.Errorf("unexpected waiting subscription client. got: %d, want: 2", waitingLen)
+		}
+		if err := subscriptionClient.Run(); err != nil {
+			t.Errorf("got error: %v, want: nil", err)
+		}
+	}()
+
+	time.Sleep(3 * time.Second)
+	length := len(subscriptionClient.GetSubscriptions())
+	if length != 2 {
+		t.Fatalf("unexpected subscription client after restart. got: %d, want: 2, subscriptions: %+v", length, subscriptionClient.currentSession.subscriptions)
+	}
+	if err := subscriptionClient.Close(); err != nil {
+		t.Fatalf("got error: %v, want: nil", err)
+	}
+}

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -110,7 +110,6 @@ func (stw *subscriptionsTransportWS) Unsubscribe(ctx *SubscriptionContext, sub S
 
 // OnMessage listens ongoing messages from server
 func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscription Subscription, message OperationMessage) error {
-
 	switch message.Type {
 	case GQLError:
 		ctx.Log(message, "server", GQLError)

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -177,24 +177,18 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 	case GQLComplete:
 		ctx.Log(message, "server", GQLComplete)
 		sub := ctx.GetSubscription(message.ID)
-		if ctx.OnSubscriptionComplete != nil {
-			if sub == nil {
-				ctx.OnSubscriptionComplete(Subscription{
-					id: message.ID,
-				})
-			} else {
-				ctx.OnSubscriptionComplete(*sub)
-				ctx.SetSubscription(sub.GetKey(), nil)
-			}
-		}
-		if sub != nil {
+
+		if sub == nil {
+			ctx.OnSubscriptionComplete(Subscription{
+				id: message.ID,
+			})
+		} else {
+			ctx.OnSubscriptionComplete(*sub)
 			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLConnectionKeepAlive:
 		ctx.Log(message, "server", GQLConnectionKeepAlive)
-		if ctx.OnConnectionAlive != nil {
-			ctx.OnConnectionAlive()
-		}
+		ctx.OnConnectionAlive()
 	case GQLConnectionAck:
 		// Expected response to the ConnectionInit message from the client acknowledging a successful connection with the server.
 		// The client is now ready to request subscription operations.
@@ -207,9 +201,8 @@ func (stw *subscriptionsTransportWS) OnMessage(ctx *SubscriptionContext, subscri
 				return nil
 			}
 		}
-		if ctx.OnConnected != nil {
-			ctx.OnConnected()
-		}
+
+		ctx.OnConnected()
 	default:
 		ctx.Log(message, "server", GQLUnknown)
 	}

--- a/subscriptions_transport_ws_test.go
+++ b/subscriptions_transport_ws_test.go
@@ -8,87 +8,7 @@ import (
 	"log"
 	"testing"
 	"time"
-
-	"github.com/coder/websocket"
 )
-
-func TestSubscription_WithRetryStatusCodes(t *testing.T) {
-	stop := make(chan bool)
-	msg := randomID()
-	disconnectedCount := 0
-	subscriptionClient := NewSubscriptionClient(fmt.Sprintf("%s/v1/graphql", hasuraTestHost)).
-		WithProtocol(GraphQLWS).
-		WithRetryStatusCodes("4400").
-		WithConnectionParams(map[string]interface{}{
-			"headers": map[string]string{
-				"x-hasura-admin-secret": "test",
-			},
-		}).WithLog(log.Println).
-		OnDisconnected(func() {
-			disconnectedCount++
-			if disconnectedCount > 5 {
-				stop <- true
-			}
-		}).
-		OnError(func(sc *SubscriptionClient, err error) error {
-			t.Fatal("should not receive error")
-			return err
-		})
-
-	/*
-		subscription {
-			user {
-				id
-				name
-			}
-		}
-	*/
-	var sub struct {
-		Users []struct {
-			ID   int    `graphql:"id"`
-			Name string `graphql:"name"`
-		} `graphql:"user(order_by: { id: desc }, limit: 5)"`
-	}
-
-	_, err := subscriptionClient.Subscribe(sub, nil, func(data []byte, e error) error {
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		log.Println("result", string(data))
-		e = json.Unmarshal(data, &sub)
-		if e != nil {
-			t.Fatalf("got error: %v, want: nil", e)
-			return nil
-		}
-
-		if len(sub.Users) > 0 && sub.Users[0].Name != msg {
-			t.Fatalf("subscription message does not match. got: %s, want: %s", sub.Users[0].Name, msg)
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		t.Fatalf("got error: %v, want: nil", err)
-	}
-
-	go func() {
-		if err := subscriptionClient.Run(); err != nil && websocket.CloseStatus(err) == 4400 {
-			t.Errorf("should not get error 4400, got error: %v, want: nil", err)
-		}
-	}()
-
-	defer subscriptionClient.Close()
-
-	// wait until the subscription client connects to the server
-	if err := waitHasuraService(60); err != nil {
-		t.Fatalf("failed to start hasura service: %s", err)
-	}
-
-	<-stop
-}
 
 func TestSubscription_parseInt32Ranges(t *testing.T) {
 	fixtures := []struct {
@@ -117,8 +37,8 @@ func TestSubscription_parseInt32Ranges(t *testing.T) {
 	}
 }
 
-func TestSubscription_closeThenRun(t *testing.T) {
-	_, subscriptionClient := hasura_setupClients(GraphQLWS)
+func TestSubscriptionsTransportWS_closeThenRun(t *testing.T) {
+	_, subscriptionClient := hasura_setupClients(SubscriptionsTransportWS)
 
 	fixtures := []struct {
 		Query        interface{}
@@ -164,14 +84,14 @@ func TestSubscription_closeThenRun(t *testing.T) {
 
 	subscriptionClient = subscriptionClient.
 		WithExitWhenNoSubscription(false).
-		WithTimeout(3 * time.Second).
+		WithReadTimeout(3 * time.Second).
+		WithWriteTimeout(5 * time.Second).
 		OnError(func(sc *SubscriptionClient, err error) error {
 			t.Fatalf("got error: %v, want: nil", err)
 			return err
 		})
 
 	bulkSubscribe := func() {
-
 		for _, f := range fixtures {
 			id, err := subscriptionClient.Subscribe(f.Query, f.Variables, func(data []byte, e error) error {
 				if e != nil {
@@ -210,7 +130,7 @@ func TestSubscription_closeThenRun(t *testing.T) {
 			return
 		}
 
-		waitingLen := subscriptionClient.getContext().GetSubscriptionsLength([]SubscriptionStatus{SubscriptionWaiting})
+		waitingLen := subscriptionClient.getCurrentSession().GetSubscriptionsLength([]SubscriptionStatus{SubscriptionWaiting})
 		if waitingLen != 2 {
 			t.Errorf("unexpected waiting subscription client. got: %d, want: 2", waitingLen)
 		}
@@ -222,7 +142,7 @@ func TestSubscription_closeThenRun(t *testing.T) {
 	time.Sleep(3 * time.Second)
 	length := len(subscriptionClient.GetSubscriptions())
 	if length != 2 {
-		t.Fatalf("unexpected subscription client after restart. got: %d, want: 2, subscriptions: %+v", length, subscriptionClient.context.subscriptions)
+		t.Fatalf("unexpected subscription client after restart. got: %d, want: 2, subscriptions: %+v", length, subscriptionClient.currentSession.subscriptions)
 	}
 	if err := subscriptionClient.Close(); err != nil {
 		t.Fatalf("got error: %v, want: nil", err)
@@ -411,7 +331,9 @@ func TestTransportWS_ResetClient(t *testing.T) {
 	}
 
 	go func() {
-
+		defer func() {
+			stop <- true
+		}()
 		// call a mutation request to send message to the subscription
 		/*
 			mutation InsertUser($objects: [user_insert_input!]!) {
@@ -455,34 +377,28 @@ func TestTransportWS_ResetClient(t *testing.T) {
 				t.Errorf("subscription key 1 not equal, got %s, want %s", subId1, sub1.GetKey())
 				return
 			}
-			if sub1.GetID() != subId1 {
-				t.Errorf("subscription id 1 not equal, got %s, want %s", subId1, sub1.GetID())
-				return
-			}
 		}
+
 		sub2 := subscriptionClient.GetSubscription(subId2)
 		if sub2 == nil {
 			t.Errorf("subscription 2 not found: %s", subId2)
-			return
-		} else {
-			if sub2.GetKey() != subId2 {
-				t.Errorf("subscription id 2 not equal, got %s, want %s", subId2, sub2.GetKey())
-				return
-			}
 
-			if sub2.GetID() != subId2 {
-				t.Errorf("subscription id 2 not equal, got %s, want %s", subId2, sub2.GetID())
-				return
-			}
+			return
+		}
+
+		if sub2.GetKey() != subId2 {
+			t.Errorf("subscription id 2 not equal, got %s, want %s", subId2, sub2.GetKey())
+
+			return
 		}
 
 		// reset the subscription
-		log.Printf("resetting the subscription client...")
+		log.Println("resetting the subscription client...")
 		if err := subscriptionClient.Run(); err != nil {
 			t.Errorf("failed to reset the subscription client. got error: %v, want: nil", err)
 		}
+
 		log.Printf("the second run was stopped")
-		stop <- true
 	}()
 
 	go func() {
@@ -500,6 +416,7 @@ func TestTransportWS_ResetClient(t *testing.T) {
 				t.Errorf("subscription id 1 should equal, got %s, want %s", subId1, sub1.GetID())
 			}
 		}
+
 		sub2 := subscriptionClient.GetSubscription(subId2)
 		if sub2 == nil {
 			t.Errorf("subscription 2 not found: %s", subId2)

--- a/subscriptions_transport_ws_test.go
+++ b/subscriptions_transport_ws_test.go
@@ -121,8 +121,6 @@ func TestSubscriptionsTransportWS_closeThenRun(t *testing.T) {
 		t.Fatalf("got error: %v, want: nil", err)
 	}
 
-	bulkSubscribe()
-
 	go func() {
 		length := len(subscriptionClient.GetSubscriptions())
 		if length != 2 {
@@ -130,9 +128,8 @@ func TestSubscriptionsTransportWS_closeThenRun(t *testing.T) {
 			return
 		}
 
-		waitingLen := subscriptionClient.getCurrentSession().GetSubscriptionsLength([]SubscriptionStatus{SubscriptionWaiting})
-		if waitingLen != 2 {
-			t.Errorf("unexpected waiting subscription client. got: %d, want: 2", waitingLen)
+		if subscriptionClient.getCurrentSession() != nil {
+			t.Errorf("unexpected nil session")
 		}
 		if err := subscriptionClient.Run(); err != nil {
 			t.Errorf("got error: %v, want: nil", err)
@@ -212,7 +209,7 @@ func TestTransportWS_OnError(t *testing.T) {
 	}
 
 	go func() {
-		unauthorizedErr := "invalid x-hasura-admin-secret/x-hasura-access-key"
+		unauthorizedErr := `invalid "x-hasura-admin-secret"/"x-hasura-access-key"`
 		err := subscriptionClient.Run()
 
 		if err == nil || err.Error() != unauthorizedErr {
@@ -232,7 +229,6 @@ func TestTransportWS_OnError(t *testing.T) {
 }
 
 func TestTransportWS_ResetClient(t *testing.T) {
-
 	stop := make(chan bool)
 	client, subscriptionClient := hasura_setupClients(SubscriptionsTransportWS)
 	msg := randomID()


### PR DESCRIPTION
close https://github.com/hasura/go-graphql-client/issues/160

- The main runner will be a singleton. Get rid of the recursive loop to avoid goroutine leaks
- Enhance the error handling. Add 2 new timeout settings `WithConnectionInitialisationTimeout` and `WithWebsocketConnectionIdleTimeout` to handle errors when the server is unresponsive. Check out [the docs](https://github.com/hasura/go-graphql-client/blob/32a4f6483e3aae1249f56e3d54124100be18bca0/README.md#connection-initialisation-timeout) for more details.