### PR TITLE
feat: introduce BindResponseHeaders option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
     - [Options](#options-1)
     - [Execute pre-built query](#execute-pre-built-query)
     - [Get extensions from response](#get-extensions-from-response)
+    - [Get headers from response](#get-headers-from-response)
     - [With operation name (deprecated)](#with-operation-name-deprecated)
     - [Raw bytes response](#raw-bytes-response)
     - [Multiple mutations with ordered map](#multiple-mutations-with-ordered-map)
@@ -753,11 +754,12 @@ type Option interface {
 client.Query(ctx context.Context, q interface{}, variables map[string]interface{}, options ...Option) error
 ```
 
-Currently, there are 3 option types:
+Currently, there are 4 option types:
 
 - `operation_name`
 - `operation_directive`
 - `bind_extensions`
+- `bind_response_headers`
 
 The operation name option is built-in because it is unique. We can use the option directly with `OperationName`.
 
@@ -880,6 +882,21 @@ if err != nil {
 
 // You can now use the `extensions` variable to access the extensions data
 fmt.Println("Extensions:", extensions)
+```
+
+### Get headers from response
+
+Use the `BindResponseHeaders` option to bind headers from the response.
+
+```go
+headers := http.Header{}
+err := client.Query(context.TODO(), &q, map[string]any{}, graphql.BindResponseHeaders(&headers))
+if err != nil {
+  panic(err)
+}
+
+fmt.Println(headers.Get("content-type"))
+// application/json
 ```
 
 ### With operation name (deprecated)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
   - [Installation](#installation)
   - [Usage](#usage)
     - [Authentication](#authentication)
+      - [WithRequestModifier](#withrequestmodifier)
+      - [OAuth2](#oauth2)
     - [Simple Query](#simple-query)
     - [Arguments and Variables](#arguments-and-variables)
     - [Custom scalar tag](#custom-scalar-tag)
@@ -37,6 +39,7 @@ For more information, see package [`github.com/shurcooL/githubv4`](https://githu
       - [Custom WebSocket client](#custom-websocket-client)
     - [Options](#options-1)
     - [Execute pre-built query](#execute-pre-built-query)
+    - [Get extensions from response](#get-extensions-from-response)
     - [With operation name (deprecated)](#with-operation-name-deprecated)
     - [Raw bytes response](#raw-bytes-response)
     - [Multiple mutations with ordered map](#multiple-mutations-with-ordered-map)
@@ -67,7 +70,22 @@ client := graphql.NewClient("https://example.com/graphql", nil)
 
 ### Authentication
 
-Some GraphQL servers may require authentication. The `graphql` package does not directly handle authentication. Instead, when creating a new client, you're expected to pass an `http.Client` that performs authentication. The easiest and recommended way to do this is to use the [`golang.org/x/oauth2`](https://golang.org/x/oauth2) package. You'll need an OAuth token with the right scopes. Then:
+Some GraphQL servers may require authentication. The `graphql` package does not directly handle authentication. Instead, when creating a new client, you're expected to pass an `http.Client` that performs authentication.
+
+#### WithRequestModifier
+
+Use `WithRequestModifier` method to inject headers into the request before sending to the GraphQL server.
+
+```go
+client := graphql.NewClient(endpoint, http.DefaultClient).
+  WithRequestModifier(func(r *http.Request) {
+	  r.Header.Set("Authorization", "random-token")
+  })
+```
+
+#### OAuth2
+
+The easiest and recommended way to do this is to use the [`golang.org/x/oauth2`](https://golang.org/x/oauth2) package. You'll need an OAuth token with the right scopes. Then:
 
 ```Go
 import "golang.org/x/oauth2"
@@ -736,6 +754,7 @@ client.Query(ctx context.Context, q interface{}, variables map[string]interface{
 ```
 
 Currently, there are 3 option types:
+
 - `operation_name`
 - `operation_directive`
 - `bind_extensions`
@@ -982,11 +1001,11 @@ Because the GraphQL query string is generated in runtime using reflection, it is
 
 ## Directories
 
-| Path                                                                                   | Synopsis                                                                                                        |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| [example/graphqldev](https://godoc.org/github.com/shurcooL/graphql/example/graphqldev) | graphqldev is a test program currently being used for developing graphql package.                               |
+| Path                                                                                   | Synopsis                                                                                                         |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [example/graphqldev](https://godoc.org/github.com/shurcooL/graphql/example/graphqldev) | graphqldev is a test program currently being used for developing graphql package.                                |
 | [ident](https://godoc.org/github.com/shurcooL/graphql/ident)                           | Package ident provides functions for parsing and converting identifier names between various naming conventions. |
-| [internal/jsonutil](https://godoc.org/github.com/shurcooL/graphql/internal/jsonutil)   | Package jsonutil provides a function for decoding JSON into a GraphQL query data structure.                     |
+| [internal/jsonutil](https://godoc.org/github.com/shurcooL/graphql/internal/jsonutil)   | Package jsonutil provides a function for decoding JSON into a GraphQL query data structure.                      |
 
 ## References
 

--- a/graphql.go
+++ b/graphql.go
@@ -163,9 +163,19 @@ func (c *Client) request(ctx context.Context, query string, variables map[string
 		if c.debug {
 			e = e.withRequest(request, reqReader)
 		}
+
 		return nil, nil, nil, nil, Errors{e}
 	}
+
 	defer resp.Body.Close()
+
+	if options != nil && options.headers != nil {
+		for key, values := range resp.Header {
+			for _, value := range values {
+				options.headers.Add(key, value)
+			}
+		}
+	}
 
 	r := resp.Body
 
@@ -350,6 +360,7 @@ func (c *Client) WithRequestModifier(f RequestModifier) *Client {
 		url:             c.url,
 		httpClient:      c.httpClient,
 		requestModifier: f,
+		debug:           c.debug,
 	}
 }
 

--- a/option.go
+++ b/option.go
@@ -1,5 +1,7 @@
 package graphql
 
+import "net/http"
+
 // OptionType represents the logic of graphql query construction
 type OptionType string
 
@@ -45,4 +47,18 @@ func (ono bindExtensionsOption) Type() OptionType {
 // BindExtensions bind the struct pointer to decode extensions from json response
 func BindExtensions(value any) Option {
 	return bindExtensionsOption{value: value}
+}
+
+// bind the struct pointer to return headers from response
+type bindResponseHeadersOption struct {
+	value *http.Header
+}
+
+func (ono bindResponseHeadersOption) Type() OptionType {
+	return "bind_extensions"
+}
+
+// BindExtensionsBindResponseHeaders bind the header response to the pointer
+func BindResponseHeaders(value *http.Header) Option {
+	return bindResponseHeadersOption{value: value}
 }

--- a/option.go
+++ b/option.go
@@ -55,7 +55,7 @@ type bindResponseHeadersOption struct {
 }
 
 func (ono bindResponseHeadersOption) Type() OptionType {
-	return "bind_extensions"
+	return "bind_response_headers"
 }
 
 // BindExtensionsBindResponseHeaders bind the header response to the pointer

--- a/query.go
+++ b/query.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"reflect"
 	"sort"
 	"strconv"
@@ -17,6 +18,7 @@ type constructOptionsOutput struct {
 	operationName       string
 	operationDirectives []string
 	extensions          any
+	headers             *http.Header
 }
 
 func (coo constructOptionsOutput) OperationDirectivesString() string {
@@ -36,6 +38,8 @@ func constructOptions(options []Option) (*constructOptionsOutput, error) {
 			output.operationName = opt.name
 		case bindExtensionsOption:
 			output.extensions = opt.value
+		case bindResponseHeadersOption:
+			output.headers = opt.value
 		default:
 			if opt.Type() != OptionTypeOperationDirective {
 				return nil, fmt.Errorf("invalid query option type: %s", option.Type())

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -20,16 +20,6 @@ const (
 	hasuraTestAdminSecret = "hasura"
 )
 
-type headerRoundTripper struct {
-	setHeaders func(req *http.Request)
-	rt         http.RoundTripper
-}
-
-func (h headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	h.setHeaders(req)
-	return h.rt.RoundTrip(req)
-}
-
 type user_insert_input map[string]interface{}
 
 func hasura_setupClients(protocol SubscriptionProtocolType) (*Client, *SubscriptionClient) {

--- a/subscription_graphql_ws_test.go
+++ b/subscription_graphql_ws_test.go
@@ -34,12 +34,10 @@ type user_insert_input map[string]interface{}
 
 func hasura_setupClients(protocol SubscriptionProtocolType) (*Client, *SubscriptionClient) {
 	endpoint := fmt.Sprintf("%s/v1/graphql", hasuraTestHost)
-	client := NewClient(endpoint, &http.Client{Transport: headerRoundTripper{
-		setHeaders: func(req *http.Request) {
-			req.Header.Set("x-hasura-admin-secret", hasuraTestAdminSecret)
-		},
-		rt: http.DefaultTransport,
-	}})
+	client := NewClient(endpoint, http.DefaultClient).
+		WithRequestModifier(func(r *http.Request) {
+			r.Header.Set("x-hasura-admin-secret", hasuraTestAdminSecret)
+		})
 
 	subscriptionClient := NewSubscriptionClient(endpoint).
 		WithProtocol(protocol).


### PR DESCRIPTION
close https://github.com/hasura/go-graphql-client/issues/161

Introduce a new `BindResponseHeaders` option to retrieve response headers via binding.

```go
headers := http.Header{}
err := client.Query(context.TODO(), &q, nil, graphql.BindResponseHeaders(&headers))
if err != nil {
  panic(err)
}

fmt.Println(headers.Get("content-type"))
// application/json
```