### PR TITLE
Indicate user agent should be descriptive

### DIFF
--- a/example/tibber/client.go
+++ b/example/tibber/client.go
@@ -48,7 +48,8 @@ func startSubscription() error {
 			HTTPClient: &http.Client{
 				Transport: headerRoundTripper{
 					setHeaders: func(req *http.Request) {
-						req.Header.Set("User-Agent", "go-graphql-client/0.9.0")
+						// Replace MyHomeAutomationPlatformReplaceMe/1.3.4 with a name that describes where you are running this client on
+						req.Header.Set("User-Agent", "MyHomeAutomationPlatformReplaceMe/1.2.3 hasura/go-graphql-client/0.13.1")
 					},
 					rt: http.DefaultTransport,
 				},


### PR DESCRIPTION
We have recently started seeing big amounts of badly having clients connecting to Tibber websocket API (reconnecting super frequently even on error - basically DDOSing us) using user agent `go-graphql-client/0.9.0`.

This PR is to indicate that the user agent should be kept up-to-date. We might need to ban `go-graphql-client/0.9.0` from connecting entirely.