### PR TITLE
feat: improve subscription logging and metrics

### DIFF
--- a/example/subscription/go.mod
+++ b/example/subscription/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/coder/websocket v1.8.12 // indirect
+	github.com/coder/websocket v1.8.13 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
 )

--- a/example/subscription/go.sum
+++ b/example/subscription/go.sum
@@ -1,5 +1,5 @@
-github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
-github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
+github.com/coder/websocket v1.8.13 h1:f3QZdXy7uGVz+4uCJy2nTZyM0yTBj8yANEHhqlXZ9FE=
+github.com/coder/websocket v1.8.13/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/example/subscription/subscription_test.go
+++ b/example/subscription/subscription_test.go
@@ -125,6 +125,15 @@ func TestTransportWS_basicTest(t *testing.T) {
 	// wait until the subscription client connects to the server
 	time.Sleep(2 * time.Second)
 
+	stats := gql.GetWebSocketStats()
+	if stats.TotalActiveConnections != 1 {
+		t.Fatalf("got total active websocket connections: %v, want: 1", stats.TotalActiveConnections)
+	}
+
+	if stats.TotalClosedConnections != 0 {
+		t.Fatalf("got total closed websocket connections: %v, want: 0", stats.TotalClosedConnections)
+	}
+
 	// call a mutation request to send message to the subscription
 	/*
 		mutation ($msg: String!) {
@@ -149,6 +158,15 @@ func TestTransportWS_basicTest(t *testing.T) {
 	}
 
 	<-stop
+
+	stats = gql.GetWebSocketStats()
+	if stats.TotalActiveConnections != 0 {
+		t.Fatalf("got total active websocket connections: %v, want: 0", stats.TotalActiveConnections)
+	}
+
+	if stats.TotalClosedConnections != 1 {
+		t.Fatalf("got total closed websocket connections: %v, want: 1", stats.TotalClosedConnections)
+	}
 }
 
 func TestTransportWS_exitWhenNoSubscription(t *testing.T) {

--- a/subscription.go
+++ b/subscription.go
@@ -1655,9 +1655,7 @@ func (ws *websocketStats) AddActiveConnection(id uuid.UUID) {
 func (ws *websocketStats) AddDeadConnection(id uuid.UUID) {
 	ws.sync.Lock()
 	defer ws.sync.Unlock()
-	if _, ok := ws.activeConnectionIDs[id]; ok {
-		delete(ws.activeConnectionIDs, id)
-	}
+	delete(ws.activeConnectionIDs, id)
 
 	ws.closedConnectionIDs[id] = true
 }

--- a/subscription.go
+++ b/subscription.go
@@ -139,7 +139,10 @@ type SubscriptionProtocol interface {
 // SubscriptionContext represents a shared context for protocol implementations with the websocket connection inside.
 type SubscriptionContext struct {
 	context.Context
-	client        *SubscriptionClient
+
+	client *SubscriptionClient
+	// The unique id across the session life-cycle.
+	sessionID     uuid.UUID
 	websocketConn WebsocketConn
 
 	connectionInitAt      time.Time
@@ -154,10 +157,15 @@ type SubscriptionContext struct {
 // Log prints condition logging with message type filters.
 func (sc *SubscriptionContext) Log(
 	message interface{},
-	source string,
+	metadata map[string]any,
 	opType OperationMessageType,
 ) {
-	sc.client.printLog(message, source, opType)
+	metadata["session_id"] = sc.sessionID
+	if conn, ok := sc.websocketConn.(*WebsocketHandler); ok {
+		metadata["connection_id"] = conn.GetID()
+	}
+
+	sc.client.printLog(message, metadata, opType)
 }
 
 // OnConnectionAlive executes the OnConnectionAlive callback if exists.
@@ -348,8 +356,12 @@ func (sc *SubscriptionContext) Close() error {
 
 	var err error
 	sc.SetClosed(true)
+	conn := sc.GetWebsocketConn()
+	sc.Log("closing the current session", map[string]any{
+		"connection_active": conn != nil,
+	}, GQLInternal)
 
-	if conn := sc.GetWebsocketConn(); conn != nil {
+	if conn != nil {
 		if sc.client.onDisconnected != nil {
 			sc.client.onDisconnected()
 		}
@@ -369,7 +381,9 @@ func (sc *SubscriptionContext) Close() error {
 // Send emits a message to the graphql server.
 func (sc *SubscriptionContext) Send(message interface{}, opType OperationMessageType) error {
 	if conn := sc.GetWebsocketConn(); conn != nil {
-		sc.Log(message, "client", opType)
+		sc.Log(message, map[string]any{
+			"source": "client",
+		}, opType)
 
 		return conn.WriteJSON(message)
 	}
@@ -379,6 +393,7 @@ func (sc *SubscriptionContext) Send(message interface{}, opType OperationMessage
 
 // initializes the websocket connection.
 func (sc *SubscriptionContext) init(parentContext context.Context) error {
+	sc.Log("initialize new session", map[string]any{}, GQLInternal)
 	now := time.Now()
 
 	for {
@@ -423,7 +438,9 @@ func (sc *SubscriptionContext) init(parentContext context.Context) error {
 
 		sc.Log(
 			fmt.Sprintf("%s. retry in %d second...", err.Error(), sc.client.retryDelay/time.Second),
-			"client",
+			map[string]any{
+				"source": "client",
+			},
 			GQLInternal,
 		)
 		time.Sleep(sc.client.retryDelay)
@@ -448,7 +465,9 @@ func (sc *SubscriptionContext) run() {
 				if errors.Is(err, io.EOF) || strings.Contains(err.Error(), "EOF") ||
 					errors.Is(err, net.ErrClosed) ||
 					strings.Contains(err.Error(), "connection reset by peer") {
-					sc.Log(err.Error(), "client", GQLConnectionError)
+					sc.Log(err.Error(), map[string]any{
+						"source": "client",
+					}, GQLConnectionError)
 					sc.client.errorChan <- errRestartSubscriptionClient
 
 					return
@@ -470,7 +489,9 @@ func (sc *SubscriptionContext) run() {
 				}
 
 				if closeStatus < 0 {
-					sc.Log(err, "server", GQL_CONNECTION_ERROR)
+					sc.Log(err, map[string]any{
+						"source": "client",
+					}, GQL_CONNECTION_ERROR)
 
 					continue
 				}
@@ -482,14 +503,18 @@ func (sc *SubscriptionContext) run() {
 					websocket.StatusTryAgainLater,
 					websocket.StatusMessageTooBig,
 					websocket.StatusInvalidFramePayloadData:
-					sc.Log(err, "server", GQL_CONNECTION_ERROR)
+					sc.Log(err, map[string]any{
+						"source": "server",
+					}, GQL_CONNECTION_ERROR)
 					sc.client.errorChan <- errRestartSubscriptionClient
 				case websocket.StatusNormalClosure, websocket.StatusAbnormalClosure:
 					// close event from websocket client, exiting...
 					_ = sc.client.close(sc)
 				default:
 					// let the user to handle unknown errors manually.
-					sc.Log(err, "server", GQL_CONNECTION_ERROR)
+					sc.Log(err, map[string]any{
+						"source": "server",
+					}, GQL_CONNECTION_ERROR)
 					sc.client.errorChan <- err
 				}
 
@@ -531,7 +556,9 @@ func (sc *SubscriptionContext) startWebsocketKeepAlive(c WebsocketConn, interval
 			// Ping the websocket. You might want to handle any potential errors.
 			err := c.Ping()
 			if err != nil {
-				sc.Log("Failed to ping server", "client", GQLInternal)
+				sc.Log("Failed to ping server", map[string]any{
+					"source": "client",
+				}, GQLInternal)
 				sc.client.errorChan <- errRestartSubscriptionClient
 
 				return
@@ -1137,7 +1164,9 @@ func (sc *SubscriptionClient) RunWithContext(ctx context.Context) error {
 						time.Since(
 							session.getConnectionInitAt(),
 						) > sc.connectionInitialisationTimeout {
-						sc.printLog("Connection initialisation timeout", "client", GQLInternal)
+						sc.printLog("Connection initialisation timeout", map[string]any{
+							"source": "client",
+						}, GQLInternal)
 						sc.errorChan <- &websocket.CloseError{
 							Code:   StatusConnectionInitialisationTimeout,
 							Reason: "Connection initialisation timeout",
@@ -1152,7 +1181,9 @@ func (sc *SubscriptionClient) RunWithContext(ctx context.Context) error {
 						) > sc.websocketConnectionIdleTimeout {
 						sc.printLog(
 							ErrWebsocketConnectionIdleTimeout.Error(),
-							"client",
+							map[string]any{
+								"source": "client",
+							},
 							GQLInternal,
 						)
 						sc.errorChan <- ErrWebsocketConnectionIdleTimeout
@@ -1269,6 +1300,8 @@ func (sc *SubscriptionClient) close(session *SubscriptionContext) error {
 		return nil
 	}
 
+	sc.printLog("close the subscription client", map[string]any{}, GQLInternal)
+
 	sc.setClientStatus(scStatusClosing)
 	if sc.cancel != nil {
 		sc.cancel()
@@ -1323,6 +1356,7 @@ func (sc *SubscriptionClient) initNewSession(ctx context.Context) (*Subscription
 
 	subContext := &SubscriptionContext{
 		client:        sc,
+		sessionID:     uuid.New(),
 		subscriptions: make(map[string]Subscription),
 	}
 
@@ -1380,7 +1414,9 @@ func (sc *SubscriptionClient) checkSubscriptionStatuses(session *SubscriptionCon
 		SubscriptionRunning,
 		SubscriptionWaiting,
 	}) == 0 {
-		session.Log("no running subscription. exiting...", "client", GQLInternal)
+		session.Log("no running subscription. exiting...", map[string]any{
+			"source": "client",
+		}, GQLInternal)
 		_ = sc.close(session)
 	}
 }
@@ -1388,7 +1424,7 @@ func (sc *SubscriptionClient) checkSubscriptionStatuses(session *SubscriptionCon
 // prints condition logging with message type filters.
 func (sc *SubscriptionClient) printLog(
 	message interface{},
-	source string,
+	metadata map[string]any,
 	opType OperationMessageType,
 ) {
 	if sc.log == nil {
@@ -1401,7 +1437,8 @@ func (sc *SubscriptionClient) printLog(
 		}
 	}
 
-	sc.log(message, source)
+	metadata["type"] = opType
+	sc.log(message, metadata)
 }
 
 // The payload format of both subscriptions-transport-ws and graphql-ws are the same.
@@ -1453,9 +1490,18 @@ func parseInt32Ranges(codes []string) ([][]int32, error) {
 type WebsocketHandler struct {
 	*websocket.Conn
 
+	// The unique id of the current websocket connections.
+	// The ID will be generated whenever initializing a new Websocket connection.
+	id uuid.UUID
+
 	ctx          context.Context
 	readTimeout  time.Duration
 	writeTimeout time.Duration
+}
+
+// GetID gets the identity of the Websocket connection.
+func (wh WebsocketHandler) GetID() uuid.UUID {
+	return wh.id
 }
 
 // WriteJSON implements the function to encode and send message in json format to the server.
@@ -1484,6 +1530,8 @@ func (wh *WebsocketHandler) Ping() error {
 
 // Close implements the function to close the websocket connection.
 func (wh *WebsocketHandler) Close() error {
+	globalWebSocketStats.AddDeadConnection(wh.id)
+
 	return wh.Conn.Close(websocket.StatusNormalClosure, "close websocket")
 }
 
@@ -1528,8 +1576,12 @@ func newWebsocketConn(
 		return nil, err
 	}
 
+	id := uuid.New()
+	globalWebSocketStats.AddActiveConnection(id)
+
 	return &WebsocketHandler{
 		Conn:         c,
+		id:           id,
 		ctx:          ctx,
 		readTimeout:  options.ReadTimeout,
 		writeTimeout: options.WriteTimeout,
@@ -1571,4 +1623,50 @@ type WebsocketOptions struct {
 	// Subprotocols hold subprotocol names of the subscription transport
 	// The graphql server depends on the Sec-WebSocket-Protocol header to return the correct message specification
 	Subprotocols []string
+}
+
+type websocketStats struct {
+	sync                sync.Mutex
+	activeConnectionIDs map[uuid.UUID]bool
+	closedConnectionIDs map[uuid.UUID]bool
+}
+
+var globalWebSocketStats = websocketStats{
+	activeConnectionIDs: map[uuid.UUID]bool{},
+	closedConnectionIDs: map[uuid.UUID]bool{},
+}
+
+// AddActiveConnection adds an active connection id to the list.
+func (ws *websocketStats) AddActiveConnection(id uuid.UUID) {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+
+	ws.activeConnectionIDs[id] = true
+}
+
+// AddDeadConnection adds an dead connection id to the list.
+func (ws *websocketStats) AddDeadConnection(id uuid.UUID) {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+	if _, ok := ws.activeConnectionIDs[id]; ok {
+		delete(ws.activeConnectionIDs, id)
+	}
+
+	ws.closedConnectionIDs[id] = true
+}
+
+// GetTotalActiveWebSocketConnections gets the total number of active websockets.
+func GetTotalActiveWebSocketConnections() int {
+	globalWebSocketStats.sync.Lock()
+	defer globalWebSocketStats.sync.Unlock()
+
+	return len(globalWebSocketStats.activeConnectionIDs)
+}
+
+// GetTotalClosedWebSocketConnections gets the total number of active websockets.
+func GetTotalClosedWebSocketConnections() int {
+	globalWebSocketStats.sync.Lock()
+	defer globalWebSocketStats.sync.Unlock()
+
+	return len(globalWebSocketStats.closedConnectionIDs)
 }

--- a/subscription_graphql_ws.go
+++ b/subscription_graphql_ws.go
@@ -91,7 +91,9 @@ func (gws *graphqlWS) OnMessage(
 ) error {
 	switch message.Type {
 	case GQLError:
-		ctx.Log(message, "server", message.Type)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, message.Type)
 		var errs Errors
 
 		jsonErr := json.Unmarshal(message.Payload, &errs)
@@ -107,7 +109,9 @@ func (gws *graphqlWS) OnMessage(
 			return nil
 		}
 	case GQLNext:
-		ctx.Log(message, "server", message.Type)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, message.Type)
 		var out struct {
 			Data   *json.RawMessage `json:"data"`
 			Errors Errors           `json:"errors"`
@@ -137,7 +141,9 @@ func (gws *graphqlWS) OnMessage(
 
 		subscription.handler(outData, nil)
 	case GQLComplete:
-		ctx.Log(message, "server", message.Type)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, message.Type)
 		sub := ctx.GetSubscription(message.ID)
 		if sub == nil {
 			ctx.OnSubscriptionComplete(Subscription{
@@ -148,7 +154,9 @@ func (gws *graphqlWS) OnMessage(
 			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLPing:
-		ctx.Log(message, "server", GQLPing)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLPing)
 		ctx.OnConnectionAlive()
 
 		// send pong response message back to the server
@@ -158,12 +166,16 @@ func (gws *graphqlWS) OnMessage(
 		}
 
 		if err := ctx.Send(msg, GQLPong); err != nil {
-			ctx.Log(err, "client", GQLInternal)
+			ctx.Log(err, map[string]any{
+				"source": "client",
+			}, GQLInternal)
 		}
 	case GQLConnectionAck:
 		// Expected response to the ConnectionInit message from the client acknowledging a successful connection with the server.
 		// The client is now ready to request subscription operations.
-		ctx.Log(message, "server", GQLConnectionAck)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLConnectionAck)
 		ctx.SetAcknowledge(true)
 
 		for id, sub := range ctx.GetSubscriptions() {
@@ -175,7 +187,9 @@ func (gws *graphqlWS) OnMessage(
 						id,
 						sub.payload.Query,
 					),
-					"client",
+					map[string]any{
+						"source": "client",
+					},
 					GQLInternal,
 				)
 
@@ -185,7 +199,9 @@ func (gws *graphqlWS) OnMessage(
 
 		ctx.OnConnected()
 	default:
-		ctx.Log(message, "server", GQLUnknown)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLUnknown)
 	}
 
 	return nil

--- a/subscriptions_transport_ws.go
+++ b/subscriptions_transport_ws.go
@@ -108,7 +108,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 ) error {
 	switch message.Type {
 	case GQLError:
-		ctx.Log(message, "server", GQLError)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLError)
 		var errs Errors
 
 		jsonErr := json.Unmarshal(message.Payload, &errs)
@@ -124,7 +126,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 			return nil
 		}
 	case GQLData:
-		ctx.Log(message, "server", GQLData)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLData)
 		var out struct {
 			Data   *json.RawMessage `json:"data"`
 			Errors Errors           `json:"errors"`
@@ -154,7 +158,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 
 		subscription.handler(outData, nil)
 	case GQLConnectionError, "conn_err":
-		ctx.Log(message, "server", GQLConnectionError)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLConnectionError)
 
 		// try to parse the error object
 		var payload any
@@ -186,7 +192,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 
 		return err
 	case GQLComplete:
-		ctx.Log(message, "server", GQLComplete)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLComplete)
 		sub := ctx.GetSubscription(message.ID)
 
 		if sub == nil {
@@ -198,12 +206,16 @@ func (stw *subscriptionsTransportWS) OnMessage(
 			ctx.SetSubscription(sub.GetKey(), nil)
 		}
 	case GQLConnectionKeepAlive:
-		ctx.Log(message, "server", GQLConnectionKeepAlive)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLConnectionKeepAlive)
 		ctx.OnConnectionAlive()
 	case GQLConnectionAck:
 		// Expected response to the ConnectionInit message from the client acknowledging a successful connection with the server.
 		// The client is now ready to request subscription operations.
-		ctx.Log(message, "server", GQLConnectionAck)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLConnectionAck)
 		ctx.SetAcknowledge(true)
 		subscriptions := ctx.GetSubscriptions()
 
@@ -216,7 +228,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 						id,
 						sub.payload.Query,
 					),
-					"client",
+					map[string]any{
+						"source": "client",
+					},
 					GQLInternal,
 				)
 
@@ -226,7 +240,9 @@ func (stw *subscriptionsTransportWS) OnMessage(
 
 		ctx.OnConnected()
 	default:
-		ctx.Log(message, "server", GQLUnknown)
+		ctx.Log(message, map[string]any{
+			"source": "server",
+		}, GQLUnknown)
 	}
 
 	return nil


### PR DESCRIPTION
This pull request introduces several enhancements to the WebSocket-based subscription system, focusing on improved logging, connection lifecycle management, and test coverage. Key changes include adding metadata to logging, tracking WebSocket connection statistics, and updating tests to verify connection states.

### Logging Enhancements:

* Updated `SubscriptionContext.Log` to accept a `metadata` map instead of a `source` string, enabling richer logging details. Metadata now includes `session_id` and `connection_id` where applicable. (`subscription.go`, [[1]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL157-R168) [[2]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL372-R386) [[3]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL426-R443) [[4]](diffhunk://#diff-81aa5c35f1b8892a5c8a8fc75a567bd3fcd57a3dcf231ee8ac2c2e35ea99d672L94-R96) [[5]](diffhunk://#diff-d9408c2261dc08d402cead6438d49185c72269fafff4872ba8505910980e1509L111-R113)

### WebSocket Connection Management:

* Introduced a `WebSocketStats` structure to track active and closed WebSocket connections, along with their unique IDs. Added methods to update and retrieve these statistics. (`subscription.go`, [subscription.goR1627-R1683](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bR1627-R1683))
* Assigned a unique `id` to each `WebsocketHandler` instance for better connection tracking. (`subscription.go`, [[1]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bR1493-R1506) [[2]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bR1579-R1584)
* Updated the `Close` method of `WebsocketHandler` to log and update connection statistics when a connection is closed. (`subscription.go`, [subscription.goR1533-R1534](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bR1533-R1534))