### PR TITLE
enhance websocket stats

### DIFF
--- a/subscription_metrics.go
+++ b/subscription_metrics.go
@@ -1,0 +1,122 @@
+package graphql
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Closed connection IDs are cached to make sure the accuracy of the gauge metric when there are duplicated closed called.
+var maxClosedConnectionCacheSize int = 100
+
+var defaultWebSocketStats = websocketStats{
+	activeConnectionIDs: map[uuid.UUID]bool{},
+	closedConnectionIDs: make([]uuid.UUID, 0, maxClosedConnectionCacheSize),
+}
+
+// GetWebSocketStats gets the websocket stats.
+func GetWebSocketStats() WebSocketStats {
+	return defaultWebSocketStats.GetStats()
+}
+
+// ResetWebSocketStats reset the websocket stats.
+func ResetWebSocketStats() {
+	defaultWebSocketStats.Reset()
+}
+
+// WebSocketStats hold statistic data of WebSocket connections for subscription.
+type WebSocketStats struct {
+	TotalActiveConnections uint
+	TotalClosedConnections uint
+	ActiveConnectionIDs    []uuid.UUID
+}
+
+type websocketStats struct {
+	sync                   sync.Mutex
+	activeConnectionIDs    map[uuid.UUID]bool
+	closedConnectionIDs    []uuid.UUID
+	totalClosedConnections uint
+}
+
+// AddActiveConnection adds an active connection id to the list.
+func (ws *websocketStats) AddActiveConnection(id uuid.UUID) {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+
+	ws.activeConnectionIDs[id] = true
+}
+
+// AddClosedConnection adds an dead connection id to the list.
+func (ws *websocketStats) AddClosedConnection(id uuid.UUID) {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+	delete(ws.activeConnectionIDs, id)
+
+	for _, item := range ws.closedConnectionIDs {
+		// do not increase if the connection id already exists in the queue
+		if item == id {
+			return
+		}
+	}
+
+	ws.totalClosedConnections++
+	if len(ws.closedConnectionIDs) < maxClosedConnectionCacheSize {
+		ws.closedConnectionIDs = append(ws.closedConnectionIDs, id)
+
+		return
+	}
+
+	for i := 1; i < maxClosedConnectionCacheSize; i++ {
+		ws.closedConnectionIDs[i-1] = ws.closedConnectionIDs[i]
+	}
+
+	ws.closedConnectionIDs[maxClosedConnectionCacheSize-1] = id
+}
+
+// Reset the websocket stats.
+func (ws *websocketStats) Reset() {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+
+	ws.activeConnectionIDs = map[uuid.UUID]bool{}
+	ws.closedConnectionIDs = make([]uuid.UUID, 0, maxClosedConnectionCacheSize)
+	ws.totalClosedConnections = 0
+}
+
+// GetStats gets the websocket stats.
+func (ws *websocketStats) GetStats() WebSocketStats {
+	ws.sync.Lock()
+	defer ws.sync.Unlock()
+
+	activeIDs := make([]uuid.UUID, 0, len(ws.activeConnectionIDs))
+	for id := range ws.activeConnectionIDs {
+		activeIDs = append(activeIDs, id)
+	}
+
+	return WebSocketStats{
+		ActiveConnectionIDs:    activeIDs,
+		TotalActiveConnections: uint(len(ws.activeConnectionIDs)),
+		TotalClosedConnections: ws.totalClosedConnections,
+	}
+}
+
+// SetMaxClosedConnectionMetricCacheSize sets the max cache size of closed connections metrics.
+func SetMaxClosedConnectionMetricCacheSize(size uint) {
+	maxClosedConnectionCacheSize = int(size)
+
+	if len(defaultWebSocketStats.closedConnectionIDs) <= maxClosedConnectionCacheSize {
+		return
+	}
+
+	defaultWebSocketStats.sync.Lock()
+	defer defaultWebSocketStats.sync.Unlock()
+
+	newSlice := make([]uuid.UUID, maxClosedConnectionCacheSize)
+	startIndex := len(defaultWebSocketStats.closedConnectionIDs) - maxClosedConnectionCacheSize
+
+	for i := 0; i < maxClosedConnectionCacheSize; i++ {
+		newSlice[i] = defaultWebSocketStats.closedConnectionIDs[startIndex+i]
+	}
+
+	defaultWebSocketStats.closedConnectionIDs = newSlice
+}

--- a/subscription_metrics_test.go
+++ b/subscription_metrics_test.go
@@ -1,0 +1,70 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestWebSocketStats(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		defaultWebSocketStats.AddActiveConnection(uuid.New())
+	}
+
+	for i := 0; i < 100; i++ {
+		defaultWebSocketStats.AddClosedConnection(uuid.New())
+	}
+
+	stats := GetWebSocketStats()
+
+	if got, expected := stats.TotalActiveConnections, 10; got != uint(expected) {
+		t.Errorf("total active connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := stats.TotalClosedConnections, 100; got != uint(expected) {
+		t.Errorf("total closed connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := len(defaultWebSocketStats.closedConnectionIDs), 100; got != expected {
+		t.Errorf("total closed connection ids, expected: %d, got: %d", expected, got)
+	}
+
+	SetMaxClosedConnectionMetricCacheSize(10)
+
+	if got, expected := stats.TotalClosedConnections, 100; got != uint(expected) {
+		t.Errorf("total closed connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := len(defaultWebSocketStats.closedConnectionIDs), 10; got != expected {
+		t.Errorf("total closed connection ids, expected: %d, got: %d", expected, got)
+	}
+
+	for i := 0; i < 10; i++ {
+		defaultWebSocketStats.AddClosedConnection(uuid.New())
+	}
+
+	stats = GetWebSocketStats()
+
+	if got, expected := stats.TotalClosedConnections, 110; got != uint(expected) {
+		t.Errorf("total closed connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := len(defaultWebSocketStats.closedConnectionIDs), 10; got != expected {
+		t.Errorf("total closed connection ids, expected: %d, got: %d", expected, got)
+	}
+
+	ResetWebSocketStats()
+	stats = GetWebSocketStats()
+
+	if got, expected := stats.TotalActiveConnections, 0; got != uint(expected) {
+		t.Errorf("total active connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := stats.TotalClosedConnections, 0; got != uint(expected) {
+		t.Errorf("total closed connections, expected: %d, got: %d", expected, got)
+	}
+
+	if got, expected := len(defaultWebSocketStats.closedConnectionIDs), 0; got != expected {
+		t.Errorf("total closed connection ids, expected: %d, got: %d", expected, got)
+	}
+}


### PR DESCRIPTION
* Replaced the global `websocketStats` instance (`globalWebSocketStats`) with a scoped `defaultWebSocketStats` instance to improve encapsulation and maintainability. (`subscription.go`: [[1]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL1533-R1533) [[2]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL1580-R1580) [[3]](diffhunk://#diff-828fe8a645cf1a278fb0dfdca1eac3d6b4c691415c66dbe854d6286e2578031bL1627-L1683)
* Moved WebSocket statistics implementation to a new file, `subscription_metrics.go`, and added functionality to manage a cache of closed connection IDs with a configurable size. (`subscription_metrics.go`: [subscription_metrics.goR1-R122](diffhunk://#diff-1e4099204a2a0f36ae798ab2b49350fb19629f18f2fdc2269f5f3081da1f0cc6R1-R122))
* Introduced methods to reset WebSocket statistics and configure the maximum size of the closed connection cache. (`subscription_metrics.go`: [subscription_metrics.goR1-R122](diffhunk://#diff-1e4099204a2a0f36ae798ab2b49350fb19629f18f2fdc2269f5f3081da1f0cc6R1-R122))