### PR TITLE
Avoid NPE when populating headers with nil response

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -443,7 +443,7 @@ func (c *Client) doRequest(
 
 	resp := c.doHttpRequest(ctx, reqReader)
 
-	if options != nil && options.headers != nil {
+	if options != nil && options.headers != nil && resp.response != nil {
 		for key, values := range resp.response.Header {
 			for _, value := range values {
 				options.headers.Add(key, value)


### PR DESCRIPTION
When using this library with the GitHub GraphQL API, I found it panics when github returns a 403 with no response. Guarding the header population behind a nil check prevents this.