### PR TITLE
fix: remove unnecessary gzip decompression   

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.20"
+          go-version: "1.22"
       - name: Install dependencies
         run: |
           go get -t -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.22"
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.22"
       - name: Install dependencies
         run: |
           go get -t -v ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,8 @@ linters:
     - mnd
     - recvcheck
     - wsl
+    - wsl_v5
+    - godoclint
     - makezero
     - godox
     - gocognit
@@ -22,6 +24,7 @@ linters:
     - forcetypeassert
     - containedctx
     - maintidx
+    - noinlineerr
   settings:
     exhaustive:
       # Program elements to check for exhaustiveness.

--- a/graphql.go
+++ b/graphql.go
@@ -736,7 +736,9 @@ const (
 	queryOperation operationType = iota
 	mutationOperation
 	// subscriptionOperation // Unused.
+)
 
+const (
 	ErrRequestError            = "request_error"
 	ErrJsonEncode              = "json_encode_error"
 	ErrJsonDecode              = "json_decode_error"

--- a/graphql.go
+++ b/graphql.go
@@ -2,7 +2,6 @@ package graphql
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -214,7 +213,6 @@ func (c *Client) doHttpRequest(ctx context.Context, body io.ReadSeeker) *rawGrap
 		}
 
 		request.Header.Add("Content-Type", "application/json")
-		request.Header.Add("Accept-Encoding", "gzip")
 
 		if c.requestModifier != nil {
 			c.requestModifier(request)
@@ -337,28 +335,6 @@ func (c *Client) decodeRawGraphQLResponse(
 	resp *http.Response,
 ) *rawGraphQLResult {
 	var r io.Reader = resp.Body
-
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gr, err := gzip.NewReader(r)
-		if err != nil {
-			return &rawGraphQLResult{
-				request:     req,
-				requestBody: reqBody,
-				Errors: Errors{
-					newError(
-						ErrJsonDecode,
-						fmt.Errorf("problem trying to create gzip reader: %w", err),
-					),
-				},
-			}
-		}
-
-		defer func() {
-			_ = gr.Close()
-		}()
-
-		r = gr
-	}
 
 	// copy the response reader for debugging
 	var respReader *bytes.Reader

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -985,10 +985,10 @@ func TestClient_Query_Compression(t *testing.T) {
 		gw.Close()
 	})
 
-	client := graphql.NewClient(
-		"/graphql",
-		&http.Client{Transport: localRoundTripper{handler: mux}},
-	)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := graphql.NewClient(server.URL+"/graphql", http.DefaultClient)
 
 	var q struct {
 		User struct {


### PR DESCRIPTION
The HTTP client can automatically decompress gzip content by the `Content-Encoding` header.  No need to do the unnecessary decompression step.

https://github.com/hasura/go-graphql-client/issues/181