### PR TITLE
fix: lint errors

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -574,6 +574,7 @@ func (c *Client) processResponse(v any, resp *rawGraphQLResult, extensions any) 
 func (c *Client) WithRequestModifier(f RequestModifier) *Client {
 	newClient := *c
 	newClient.requestModifier = f
+
 	return &newClient
 }
 
@@ -581,6 +582,7 @@ func (c *Client) WithRequestModifier(f RequestModifier) *Client {
 func (c *Client) WithDebug(debug bool) *Client {
 	newClient := *c
 	newClient.debug = debug
+
 	return &newClient
 }
 


### PR DESCRIPTION
This pull request makes a minor update to the `graphql.go` file, specifically in two methods that return modified copies of the `Client` struct. The change adds a blank line for improved readability after the assignment of the new field in both methods.

* Code readability:
  * Added a blank line before the return statement in both `WithRequestModifier` and `WithDebug` methods to improve code clarity.